### PR TITLE
Build full Python course platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,61 @@
-# TestProject
-Project writed on Gemini 2.5Pro + ChatGPT 5
+# Python Mastery Learning Platform
+
+Полноценная платформа для обучения Python от нуля до уровня Middle, включающая backend на Flask и frontend на React + Tailwind CSS. Реализованы регистрация, авторизация с JWT, симуляция покупки курса, управление прогрессом и мощная админ-панель с WYSIWYG-редактором.
+
+## Особенности
+- **Backend**: Flask, SQLAlchemy, JWT, защита CSRF/XSS через безопасные практики, хэширование паролей (bcrypt), email-уведомления (логируются в консоль).
+- **Frontend**: Vite + React + Tailwind CSS, адаптивный дизайн, темная/светлая тема, плавные анимации (Framer Motion), поддержка от 320px.
+- **База**: SQLite по умолчанию (легко заменить на PostgreSQL через переменную окружения `DATABASE_URL`).
+- **Курс**: Иерархия курсов → глав → подразделов → уроков. Уроки содержат текст, видео, вложения и прогресс пользователя.
+- **Админ-панель**: Управление пользователями и контентом, блокировка, уведомления, добавление глав/уроков через WYSIWYG (CKEditor).
+
+## Быстрый старт
+
+### Backend
+```bash
+cd backend
+python -m venv .venv
+source .venv/bin/activate  # Windows: .venv\\Scripts\\activate
+pip install -r requirements.txt
+flask --app app.py shell  # по желанию для проверки
+flask --app app.py db upgrade  # если используете миграции
+flask --app app.py seed        # заполнение демо-данными (создаст admin@example.com/admin123)
+flask --app app.py run
+```
+Backend запустится на `http://localhost:5000`.
+
+### Frontend
+```bash
+cd frontend
+npm install
+npm run dev
+```
+Интерфейс доступен на `http://localhost:5173`. Vite проксирует запросы `/api` на Flask.
+
+## Учётные записи
+- **Админ**: `admin@example.com / admin123`
+- **Новый пользователь**: регистрируется через интерфейс.
+
+## Структура проекта
+```
+backend/  – Flask-приложение (модели, маршруты, сиды)
+frontend/ – Vite + React приложение
+```
+
+## Тестовые данные
+После выполнения команды `flask --app app.py seed` доступен курс «Python Mastery» с двумя главами:
+- Глава 1: Основы Python (переменные, условные операторы, циклы)
+- Глава 2: Встроенные библиотеки (os/sys, datetime, collections/itertools)
+
+## Безопасность
+- JWT с дополнительными claim-ами (роль, статус, тариф)
+- Валидация email/паролей, хэширование bcrypt
+- Обработчики ошибок и запрет доступа для заблокированных пользователей
+- Логирование админ-действий и email-уведомлений
+
+## Дальнейшее развитие
+- Интеграция с реальным платежным провайдером (Stripe/ЮKassa)
+- Добавление метрик прогресса, чатов и лайв-сессий
+- Экспорт сертификатов в PDF
+
+Приятного обучения!

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from flask import Flask, jsonify
+
+from .config import Config
+from .extensions import db, init_extensions, jwt
+from .models import AdminLog, User
+from .routes.admin import admin_bp
+from .routes.auth import auth_bp
+from .routes.courses import courses_bp
+from .routes.users import user_bp
+from .seed import seed_database
+
+
+def create_app(config_class: type[Config] = Config) -> Flask:
+    app = Flask(__name__)
+    app.config.from_object(config_class)
+
+    Path(app.instance_path).mkdir(parents=True, exist_ok=True)
+
+    init_extensions(app)
+    register_error_handlers(app)
+    register_shellcontext(app)
+    register_jwt_callbacks()
+    register_blueprints(app)
+
+    @app.cli.command("seed")
+    def seed_command():
+        seed_database()
+        print("Database seeded with demo data")
+
+    return app
+
+
+def register_blueprints(app: Flask) -> None:
+    app.register_blueprint(auth_bp, url_prefix="/api/auth")
+    app.register_blueprint(user_bp, url_prefix="/api/user")
+    app.register_blueprint(courses_bp, url_prefix="/api/courses")
+    app.register_blueprint(admin_bp, url_prefix="/api/admin")
+
+
+def register_error_handlers(app: Flask) -> None:
+    @app.errorhandler(404)
+    def not_found(error):
+        return jsonify({"error": "Not found", "message": str(error)}), 404
+
+    @app.errorhandler(400)
+    def bad_request(error):
+        return jsonify({"error": "Bad request", "message": str(error)}), 400
+
+    @app.errorhandler(401)
+    def unauthorized(error):
+        return jsonify({"error": "Unauthorized", "message": str(error)}), 401
+
+    @app.errorhandler(403)
+    def forbidden(error):
+        return jsonify({"error": "Forbidden", "message": str(error)}), 403
+
+    @app.errorhandler(500)
+    def server_error(error):
+        return jsonify({"error": "Server error", "message": str(error)}), 500
+
+
+def register_shellcontext(app: Flask) -> None:
+    @app.shell_context_processor
+    def shell_context():
+        return {"db": db, "User": User, "AdminLog": AdminLog}
+
+
+def register_jwt_callbacks() -> None:
+    @jwt.additional_claims_loader
+    def add_claims(identity):
+        user = User.query.get(identity)
+        return {
+            "is_admin": user.is_admin if user else False,
+            "status": user.status if user else "inactive",
+            "tier": user.tier if user else "basic",
+        }
+
+    @jwt.user_identity_loader
+    def user_identity_lookup(user: User | int):
+        if isinstance(user, User):
+            return user.id
+        return user
+
+    @jwt.user_lookup_loader
+    def user_lookup_callback(_jwt_header, jwt_data):
+        identity = jwt_data["sub"]
+        return User.query.get(identity)
+
+    @jwt.token_in_blocklist_loader
+    def check_if_token_revoked(jwt_header, jwt_payload):
+        # Simple placeholder for blacklisting.
+        return False
+
+    @jwt.invalid_token_loader
+    def invalid_token(reason: str):
+        return jsonify({"error": "Invalid token", "message": reason}), 401
+
+    @jwt.expired_token_loader
+    def expired_token(jwt_header, jwt_payload):
+        return jsonify({"error": "Token expired"}), 401
+
+    @jwt.revoked_token_loader
+    def revoked_token(jwt_header, jwt_payload):
+        return jsonify({"error": "Token revoked"}), 401
+
+
+if __name__ == "__main__":
+    application = create_app()
+    with application.app_context():
+        db.create_all()
+        if not User.query.filter_by(email="admin@example.com").first():
+            seed_database()
+    application.run(debug=True)
+

--- a/backend/config.py
+++ b/backend/config.py
@@ -1,0 +1,30 @@
+import os
+from datetime import timedelta
+
+
+class Config:
+    SECRET_KEY = os.environ.get("SECRET_KEY", "super-secret-key")
+    SQLALCHEMY_DATABASE_URI = os.environ.get(
+        "DATABASE_URL",
+        f"sqlite:///{os.path.join(os.path.dirname(__file__), 'app.db')}"
+    )
+    SQLALCHEMY_TRACK_MODIFICATIONS = False
+    JWT_SECRET_KEY = os.environ.get("JWT_SECRET_KEY", "jwt-secret-key")
+    JWT_ACCESS_TOKEN_EXPIRES = timedelta(hours=2)
+    JWT_REFRESH_TOKEN_EXPIRES = timedelta(days=30)
+    SECURITY_PASSWORD_SALT = os.environ.get("SECURITY_PASSWORD_SALT", "password-salt")
+    FRONTEND_URL = os.environ.get("FRONTEND_URL", "http://localhost:5173")
+    MAIL_SENDER = os.environ.get("MAIL_SENDER", "no-reply@pythonmastery.com")
+    MAIL_SUPPRESS_SEND = os.environ.get("MAIL_SUPPRESS_SEND", "True") == "True"
+    ALLOWED_ORIGINS = os.environ.get("ALLOWED_ORIGINS", "*")
+    LOG_FILE = os.environ.get(
+        "ADMIN_LOG_FILE",
+        os.path.join(os.path.dirname(__file__), "admin_actions.log")
+    )
+
+
+class TestConfig(Config):
+    SQLALCHEMY_DATABASE_URI = "sqlite:///:memory:"
+    TESTING = True
+    WTF_CSRF_ENABLED = False
+

--- a/backend/extensions.py
+++ b/backend/extensions.py
@@ -1,0 +1,20 @@
+from flask_sqlalchemy import SQLAlchemy
+from flask_migrate import Migrate
+from flask_bcrypt import Bcrypt
+from flask_jwt_extended import JWTManager
+from flask_cors import CORS
+
+
+db = SQLAlchemy()
+migrate = Migrate()
+bcrypt = Bcrypt()
+jwt = JWTManager()
+
+
+def init_extensions(app):
+    db.init_app(app)
+    migrate.init_app(app, db)
+    bcrypt.init_app(app)
+    jwt.init_app(app)
+    CORS(app, resources={r"/api/*": {"origins": app.config.get("ALLOWED_ORIGINS", "*")}})
+

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,0 +1,164 @@
+from datetime import datetime
+from enum import Enum
+
+from sqlalchemy import func
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from .extensions import db
+
+
+class UserStatus(Enum):
+    ACTIVE = "active"
+    BLOCKED = "blocked"
+
+
+class SubscriptionTier(Enum):
+    BASIC = "basic"
+    PREMIUM = "premium"
+
+
+class TimestampMixin:
+    created_at: Mapped[datetime] = mapped_column(
+        default=datetime.utcnow, server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        default=datetime.utcnow,
+        onupdate=datetime.utcnow,
+        server_default=func.now(),
+        nullable=False,
+    )
+
+
+class User(db.Model, TimestampMixin):
+    __tablename__ = "users"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    email: Mapped[str] = mapped_column(unique=True, nullable=False)
+    password_hash: Mapped[str] = mapped_column(nullable=False)
+    full_name: Mapped[str | None]
+    status: Mapped[str] = mapped_column(default=UserStatus.ACTIVE.value, nullable=False)
+    tier: Mapped[str] = mapped_column(default=SubscriptionTier.BASIC.value, nullable=False)
+    is_admin: Mapped[bool] = mapped_column(default=False, nullable=False)
+    last_login_at: Mapped[datetime | None]
+
+    purchases: Mapped[list["Purchase"]] = relationship(back_populates="user")
+    progresses: Mapped[list["LessonProgress"]] = relationship(back_populates="user")
+    notifications: Mapped[list["Notification"]] = relationship(back_populates="user")
+
+    def __repr__(self) -> str:  # pragma: no cover - debug helper
+        return f"<User {self.email}>"
+
+
+class Course(db.Model, TimestampMixin):
+    __tablename__ = "courses"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    title: Mapped[str] = mapped_column(nullable=False)
+    description: Mapped[str]
+    level: Mapped[str] = mapped_column(default="beginner", nullable=False)
+    price: Mapped[float] = mapped_column(default=0.0, nullable=False)
+    is_active: Mapped[bool] = mapped_column(default=True, nullable=False)
+    hero_video_url: Mapped[str | None]
+    slug: Mapped[str] = mapped_column(unique=True, nullable=False)
+
+    chapters: Mapped[list["Chapter"]] = relationship(
+        back_populates="course", cascade="all, delete-orphan"
+    )
+    purchases: Mapped[list["Purchase"]] = relationship(back_populates="course")
+
+
+class Chapter(db.Model, TimestampMixin):
+    __tablename__ = "chapters"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    title: Mapped[str] = mapped_column(nullable=False)
+    order_index: Mapped[int] = mapped_column(default=0, nullable=False)
+    course_id: Mapped[int] = mapped_column(db.ForeignKey("courses.id"), nullable=False)
+
+    course: Mapped[Course] = relationship(back_populates="chapters")
+    sections: Mapped[list["Section"]] = relationship(
+        back_populates="chapter", cascade="all, delete-orphan"
+    )
+
+
+class Section(db.Model, TimestampMixin):
+    __tablename__ = "sections"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    title: Mapped[str] = mapped_column(nullable=False)
+    order_index: Mapped[int] = mapped_column(default=0, nullable=False)
+    summary: Mapped[str | None]
+    chapter_id: Mapped[int] = mapped_column(db.ForeignKey("chapters.id"), nullable=False)
+
+    chapter: Mapped[Chapter] = relationship(back_populates="sections")
+    lessons: Mapped[list["Lesson"]] = relationship(
+        back_populates="section", cascade="all, delete-orphan"
+    )
+
+
+class Lesson(db.Model, TimestampMixin):
+    __tablename__ = "lessons"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    title: Mapped[str] = mapped_column(nullable=False)
+    order_index: Mapped[int] = mapped_column(default=0, nullable=False)
+    content: Mapped[str] = mapped_column(default="", nullable=False)
+    video_url: Mapped[str | None]
+    estimated_minutes: Mapped[int] = mapped_column(default=15, nullable=False)
+    attachments: Mapped[str | None]
+    section_id: Mapped[int] = mapped_column(db.ForeignKey("sections.id"), nullable=False)
+
+    section: Mapped[Section] = relationship(back_populates="lessons")
+    progresses: Mapped[list["LessonProgress"]] = relationship(back_populates="lesson")
+
+
+class LessonProgress(db.Model, TimestampMixin):
+    __tablename__ = "lesson_progress"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    user_id: Mapped[int] = mapped_column(db.ForeignKey("users.id"), nullable=False)
+    lesson_id: Mapped[int] = mapped_column(db.ForeignKey("lessons.id"), nullable=False)
+    completed: Mapped[bool] = mapped_column(default=False, nullable=False)
+    completed_at: Mapped[datetime | None]
+
+    user: Mapped[User] = relationship(back_populates="progresses")
+    lesson: Mapped[Lesson] = relationship(back_populates="progresses")
+
+
+class Purchase(db.Model, TimestampMixin):
+    __tablename__ = "purchases"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    user_id: Mapped[int] = mapped_column(db.ForeignKey("users.id"), nullable=False)
+    course_id: Mapped[int] = mapped_column(db.ForeignKey("courses.id"), nullable=False)
+    status: Mapped[str] = mapped_column(default="pending", nullable=False)
+    tier: Mapped[str] = mapped_column(default=SubscriptionTier.BASIC.value, nullable=False)
+    transaction_reference: Mapped[str | None]
+
+    user: Mapped[User] = relationship(back_populates="purchases")
+    course: Mapped[Course] = relationship(back_populates="purchases")
+
+
+class Notification(db.Model, TimestampMixin):
+    __tablename__ = "notifications"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    user_id: Mapped[int] = mapped_column(db.ForeignKey("users.id"), nullable=False)
+    title: Mapped[str] = mapped_column(nullable=False)
+    message: Mapped[str] = mapped_column(nullable=False)
+    is_read: Mapped[bool] = mapped_column(default=False, nullable=False)
+    category: Mapped[str] = mapped_column(default="general", nullable=False)
+
+    user: Mapped[User] = relationship(back_populates="notifications")
+
+
+class AdminLog(db.Model, TimestampMixin):
+    __tablename__ = "admin_logs"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    admin_id: Mapped[int] = mapped_column(db.ForeignKey("users.id"), nullable=False)
+    action: Mapped[str] = mapped_column(nullable=False)
+    metadata: Mapped[str | None]
+
+    admin: Mapped[User] = relationship()
+

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,15 @@
+Flask==2.3.3
+Flask-SQLAlchemy==3.0.5
+Flask-Migrate==4.0.4
+Flask-Bcrypt==1.0.1
+Flask-JWT-Extended==4.6.0
+Flask-Cors==3.0.10
+python-dotenv==1.0.0
+SQLAlchemy==2.0.21
+marshmallow==3.20.1
+marshmallow-sqlalchemy==0.29.0
+email-validator==2.1.0.post1
+itsdangerous==2.1.2
+pytz==2023.3
+psycopg2-binary==2.9.7
+alembic==1.11.1

--- a/backend/routes/admin.py
+++ b/backend/routes/admin.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime
+
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import current_user, jwt_required
+
+from ..extensions import db
+from ..models import (
+    AdminLog,
+    Chapter,
+    Course,
+    Lesson,
+    Notification,
+    Section,
+    SubscriptionTier,
+    User,
+    UserStatus,
+)
+from ..schemas.course import CourseSchema
+from ..schemas.user import UserSchema
+from ..utils.decorators import admin_required
+from ..utils.email import send_email
+
+admin_bp = Blueprint("admin", __name__)
+admin_user_schema = UserSchema(many=True)
+course_schema = CourseSchema()
+
+
+def _log_admin_action(action: str, metadata: dict | None = None) -> None:
+    entry = AdminLog(admin_id=current_user.id, action=action, metadata=json.dumps(metadata or {}))
+    db.session.add(entry)
+    db.session.commit()
+
+
+@admin_bp.get("/users")
+@jwt_required()
+@admin_required
+def list_users():
+    users = User.query.order_by(User.created_at.desc()).all()
+    return jsonify({"users": admin_user_schema.dump(users)})
+
+
+@admin_bp.patch("/users/<int:user_id>")
+@jwt_required()
+@admin_required
+def update_user(user_id: int):
+    user = User.query.get_or_404(user_id)
+    payload = request.get_json() or {}
+
+    if "full_name" in payload:
+        user.full_name = payload["full_name"]
+    if "tier" in payload and payload["tier"] in {t.value for t in SubscriptionTier}:
+        user.tier = payload["tier"]
+    if "status" in payload and payload["status"] in {s.value for s in UserStatus}:
+        user.status = payload["status"]
+        if user.status == UserStatus.BLOCKED.value:
+            send_email(
+                subject="Доступ приостановлен",
+                recipient=user.email,
+                body="Администратор временно заблокировал ваш аккаунт.",
+            )
+    db.session.commit()
+    _log_admin_action("update_user", {"user_id": user.id, "payload": payload})
+    return jsonify({"message": "User updated"})
+
+
+@admin_bp.delete("/users/<int:user_id>")
+@jwt_required()
+@admin_required
+def delete_user(user_id: int):
+    user = User.query.get_or_404(user_id)
+    db.session.delete(user)
+    db.session.commit()
+    _log_admin_action("delete_user", {"user_id": user.id})
+    return jsonify({"message": "User deleted"})
+
+
+@admin_bp.post("/users/<int:user_id>/notify")
+@jwt_required()
+@admin_required
+def notify_user(user_id: int):
+    user = User.query.get_or_404(user_id)
+    payload = request.get_json() or {}
+    title = payload.get("title", "Новое уведомление")
+    message = payload.get("message", "")
+
+    notification = Notification(user_id=user.id, title=title, message=message)
+    db.session.add(notification)
+    db.session.commit()
+    _log_admin_action("notify_user", {"user_id": user.id, "title": title})
+
+    send_email(subject=title, recipient=user.email, body=message)
+    return jsonify({"message": "Notification sent"})
+
+
+@admin_bp.post("/courses")
+@jwt_required()
+@admin_required
+def create_course():
+    payload = request.get_json() or {}
+    course = Course(
+        title=payload.get("title", "Новый курс"),
+        description=payload.get("description", ""),
+        level=payload.get("level", "beginner"),
+        price=payload.get("price", 0.0),
+        slug=payload.get("slug"),
+        hero_video_url=payload.get("hero_video_url"),
+    )
+    if not course.slug:
+        return jsonify({"error": "Slug is required"}), 400
+
+    db.session.add(course)
+    db.session.commit()
+    _log_admin_action("create_course", {"course_id": course.id})
+    return jsonify({"course": course_schema.dump(course)}), 201
+
+
+@admin_bp.put("/courses/<int:course_id>")
+@jwt_required()
+@admin_required
+def update_course(course_id: int):
+    course = Course.query.get_or_404(course_id)
+    payload = request.get_json() or {}
+
+    for attr in ["title", "description", "level", "price", "hero_video_url", "slug", "is_active"]:
+        if attr in payload:
+            setattr(course, attr, payload[attr])
+    db.session.commit()
+    _log_admin_action("update_course", {"course_id": course.id})
+    return jsonify({"course": course_schema.dump(course)})
+
+
+@admin_bp.delete("/courses/<int:course_id>")
+@jwt_required()
+@admin_required
+def delete_course(course_id: int):
+    course = Course.query.get_or_404(course_id)
+    db.session.delete(course)
+    db.session.commit()
+    _log_admin_action("delete_course", {"course_id": course.id})
+    return jsonify({"message": "Course removed"})
+
+
+@admin_bp.post("/courses/<int:course_id>/chapters")
+@jwt_required()
+@admin_required
+def create_chapter(course_id: int):
+    course = Course.query.get_or_404(course_id)
+    payload = request.get_json() or {}
+    chapter = Chapter(
+        course_id=course.id,
+        title=payload.get("title", "Новая глава"),
+        order_index=payload.get("order_index", len(course.chapters)),
+    )
+    db.session.add(chapter)
+    db.session.commit()
+    _log_admin_action("create_chapter", {"chapter_id": chapter.id})
+    return jsonify({"message": "Chapter created", "chapter_id": chapter.id}), 201
+
+
+@admin_bp.post("/chapters/<int:chapter_id>/sections")
+@jwt_required()
+@admin_required
+def create_section(chapter_id: int):
+    chapter = Chapter.query.get_or_404(chapter_id)
+    payload = request.get_json() or {}
+    section = Section(
+        chapter_id=chapter.id,
+        title=payload.get("title", "Новый раздел"),
+        summary=payload.get("summary"),
+        order_index=payload.get("order_index", len(chapter.sections)),
+    )
+    db.session.add(section)
+    db.session.commit()
+    _log_admin_action("create_section", {"section_id": section.id})
+    return jsonify({"message": "Section created", "section_id": section.id}), 201
+
+
+@admin_bp.post("/sections/<int:section_id>/lessons")
+@jwt_required()
+@admin_required
+def create_lesson(section_id: int):
+    section = Section.query.get_or_404(section_id)
+    payload = request.get_json() or {}
+    lesson = Lesson(
+        section_id=section.id,
+        title=payload.get("title", "Новый урок"),
+        content=payload.get("content", ""),
+        video_url=payload.get("video_url"),
+        attachments=json.dumps(payload.get("attachments", [])),
+        order_index=payload.get("order_index", len(section.lessons)),
+        estimated_minutes=payload.get("estimated_minutes", 15),
+    )
+    db.session.add(lesson)
+    db.session.commit()
+    _log_admin_action("create_lesson", {"lesson_id": lesson.id})
+    return jsonify({"message": "Lesson created", "lesson_id": lesson.id}), 201
+
+
+@admin_bp.put("/lessons/<int:lesson_id>")
+@jwt_required()
+@admin_required
+def update_lesson(lesson_id: int):
+    lesson = Lesson.query.get_or_404(lesson_id)
+    payload = request.get_json() or {}
+
+    for attr in ["title", "content", "video_url", "order_index", "estimated_minutes"]:
+        if attr in payload:
+            setattr(lesson, attr, payload[attr])
+    if "attachments" in payload:
+        lesson.attachments = json.dumps(payload["attachments"])
+
+    db.session.commit()
+    _log_admin_action("update_lesson", {"lesson_id": lesson.id})
+    return jsonify({"message": "Lesson updated"})
+
+
+@admin_bp.post("/preview")
+@jwt_required()
+@admin_required
+def preview_content():
+    payload = request.get_json() or {}
+    content = payload.get("content", "")
+    return jsonify({"preview": content})
+

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from email_validator import EmailNotValidError, validate_email
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import (
+    create_access_token,
+    create_refresh_token,
+    get_jwt_identity,
+    jwt_required,
+)
+from itsdangerous import URLSafeTimedSerializer
+
+from ..extensions import bcrypt, db
+from ..models import User, UserStatus
+from ..utils.email import send_email
+
+auth_bp = Blueprint("auth", __name__)
+
+
+def _generate_reset_serializer() -> URLSafeTimedSerializer:
+    from flask import current_app
+
+    return URLSafeTimedSerializer(
+        current_app.config["SECRET_KEY"],
+        salt=current_app.config["SECURITY_PASSWORD_SALT"],
+    )
+
+
+@auth_bp.post("/register")
+def register():
+    payload = request.get_json() or {}
+    email = payload.get("email", "").strip().lower()
+    password = payload.get("password", "")
+    full_name = payload.get("full_name")
+
+    try:
+        validate_email(email, check_deliverability=False)
+    except EmailNotValidError as exc:
+        return jsonify({"error": "Invalid email", "message": str(exc)}), 400
+
+    if len(password) < 8 or password.isalpha() or password.isdigit():
+        return jsonify({"error": "Weak password", "message": "Password must contain letters and digits and be at least 8 characters."}), 400
+
+    if User.query.filter_by(email=email).first():
+        return jsonify({"error": "Email exists", "message": "Account already registered"}), 409
+
+    password_hash = bcrypt.generate_password_hash(password).decode("utf-8")
+    user = User(email=email, password_hash=password_hash, full_name=full_name)
+    db.session.add(user)
+    db.session.commit()
+
+    access_token = create_access_token(identity=user.id)
+    refresh_token = create_refresh_token(identity=user.id)
+
+    send_email(
+        subject="Добро пожаловать в Python Mastery",
+        recipient=user.email,
+        body="Спасибо за регистрацию! Начните изучение Python прямо сейчас.",
+    )
+
+    return (
+        jsonify(
+            {
+                "message": "Registration successful",
+                "access_token": access_token,
+                "refresh_token": refresh_token,
+                "user": {
+                    "id": user.id,
+                    "email": user.email,
+                    "full_name": user.full_name,
+                },
+            }
+        ),
+        201,
+    )
+
+
+@auth_bp.post("/login")
+def login():
+    payload = request.get_json() or {}
+    email = payload.get("email", "").strip().lower()
+    password = payload.get("password", "")
+
+    user = User.query.filter_by(email=email).first()
+    if not user or not bcrypt.check_password_hash(user.password_hash, password):
+        return jsonify({"error": "Invalid credentials"}), 401
+
+    if user.status != UserStatus.ACTIVE.value:
+        return jsonify({"error": "Account blocked"}), 403
+
+    user.last_login_at = datetime.utcnow()
+    db.session.commit()
+
+    access_token = create_access_token(identity=user.id)
+    refresh_token = create_refresh_token(identity=user.id)
+
+    return jsonify(
+        {
+            "message": "Login successful",
+            "access_token": access_token,
+            "refresh_token": refresh_token,
+            "user": {
+                "id": user.id,
+                "email": user.email,
+                "full_name": user.full_name,
+                "is_admin": user.is_admin,
+            },
+        }
+    )
+
+
+@auth_bp.post("/refresh")
+@jwt_required(refresh=True)
+def refresh_token():
+    identity = get_jwt_identity()
+    access_token = create_access_token(identity=identity)
+    return jsonify({"access_token": access_token})
+
+
+@auth_bp.post("/forgot-password")
+def forgot_password():
+    payload = request.get_json() or {}
+    email = payload.get("email", "").strip().lower()
+    user = User.query.filter_by(email=email).first()
+    if not user:
+        return jsonify({"message": "If the account exists, an email was sent."})
+
+    serializer = _generate_reset_serializer()
+    token = serializer.dumps(email)
+    reset_url = f"{request.host_url.rstrip('/')}/reset-password?token={token}"
+    send_email(
+        subject="Сброс пароля",
+        recipient=email,
+        body=f"Перейдите по ссылке для восстановления пароля: {reset_url}",
+    )
+    return jsonify({"message": "Password reset instructions sent."})
+
+
+@auth_bp.post("/reset-password")
+def reset_password():
+    payload = request.get_json() or {}
+    token = payload.get("token")
+    new_password = payload.get("password", "")
+
+    if not token:
+        return jsonify({"error": "Missing token"}), 400
+
+    if len(new_password) < 8:
+        return jsonify({"error": "Weak password"}), 400
+
+    serializer = _generate_reset_serializer()
+    try:
+        email = serializer.loads(token, max_age=60 * 60 * 24)
+    except Exception:
+        return jsonify({"error": "Invalid or expired token"}), 400
+
+    user = User.query.filter_by(email=email).first()
+    if not user:
+        return jsonify({"error": "User not found"}), 404
+
+    user.password_hash = bcrypt.generate_password_hash(new_password).decode("utf-8")
+    db.session.commit()
+    return jsonify({"message": "Password updated"})
+

--- a/backend/routes/courses.py
+++ b/backend/routes/courses.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from random import randint
+from time import sleep
+
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import current_user, jwt_required
+
+from ..extensions import db
+from ..models import Course, Lesson, Purchase, SubscriptionTier
+from ..schemas.course import CourseSchema, LessonSchema
+from ..schemas.purchase import PurchaseSchema
+from ..utils.decorators import user_active_required
+
+courses_bp = Blueprint("courses", __name__)
+course_schema = CourseSchema(many=True)
+course_detail_schema = CourseSchema()
+lesson_schema = LessonSchema()
+purchase_schema = PurchaseSchema()
+
+
+@courses_bp.get("/")
+def list_courses():
+    level = request.args.get("level")
+    query = Course.query.filter_by(is_active=True)
+    if level:
+        query = query.filter(Course.level == level)
+    search = request.args.get("search")
+    if search:
+        query = query.filter(Course.title.ilike(f"%{search}%"))
+    courses = query.order_by(Course.created_at.desc()).all()
+    return jsonify({"courses": course_schema.dump(courses)})
+
+
+@courses_bp.get("/<slug>")
+def course_detail(slug: str):
+    course = Course.query.filter_by(slug=slug).first_or_404()
+    return jsonify({"course": course_detail_schema.dump(course)})
+
+
+@courses_bp.get("/<slug>/lessons/<int:lesson_id>")
+@jwt_required(optional=True)
+def lesson_detail(slug: str, lesson_id: int):
+    course = Course.query.filter_by(slug=slug).first_or_404()
+    lesson = Lesson.query.filter_by(id=lesson_id).first_or_404()
+
+    is_unlocked = False
+    if current_user:
+        is_unlocked = any(
+            purchase.course_id == course.id and purchase.status == "paid"
+            for purchase in current_user.purchases
+        )
+
+    if not is_unlocked and not lesson.order_index == 0:
+        return jsonify({"error": "Purchase required"}), 402
+
+    return jsonify({"lesson": lesson_schema.dump(lesson)})
+
+
+@courses_bp.post("/<slug>/purchase")
+@jwt_required()
+@user_active_required
+def purchase_course(slug: str):
+    course = Course.query.filter_by(slug=slug).first_or_404()
+    payload = request.get_json() or {}
+    tier = payload.get("tier", SubscriptionTier.PREMIUM.value)
+
+    purchase = Purchase.query.filter_by(course_id=course.id, user_id=current_user.id).first()
+    if purchase and purchase.status == "paid":
+        return jsonify({"message": "Course already purchased"})
+
+    if purchase is None:
+        purchase = Purchase(course_id=course.id, user_id=current_user.id)
+        db.session.add(purchase)
+
+    purchase.tier = tier
+    purchase.status = "processing"
+    db.session.commit()
+
+    # Simulate payment delay and completion
+    spinner_duration = int(payload.get("duration", 3))
+    spinner_duration = max(1, min(spinner_duration, 10))
+    sleep(spinner_duration)
+
+    purchase.status = "paid"
+    purchase.transaction_reference = f"PY-{randint(100000, 999999)}"
+    db.session.commit()
+
+    return jsonify(
+        {
+            "message": "Course purchased successfully",
+            "purchase": purchase_schema.dump(purchase),
+        }
+    )
+
+
+@courses_bp.get("/<slug>/progress")
+@jwt_required()
+@user_active_required
+def course_progress(slug: str):
+    course = Course.query.filter_by(slug=slug).first_or_404()
+    total_lessons = sum(len(section.lessons) for chapter in course.chapters for section in chapter.sections)
+    if total_lessons == 0:
+        return jsonify({"progress": 0})
+
+    completed = sum(
+        1
+        for chapter in course.chapters
+        for section in chapter.sections
+        for lesson in section.lessons
+        if any(p.lesson_id == lesson.id and p.completed for p in current_user.progresses)
+    )
+    progress_percentage = completed / total_lessons * 100
+    return jsonify({"progress": round(progress_percentage, 2)})
+

--- a/backend/routes/users.py
+++ b/backend/routes/users.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import current_user, jwt_required
+
+from ..extensions import db
+from ..models import Lesson, LessonProgress, Notification, SubscriptionTier
+from ..schemas.purchase import PurchaseSchema
+from ..schemas.user import NotificationSchema, UserSchema
+from ..utils.decorators import user_active_required
+from ..utils.email import send_email
+
+user_bp = Blueprint("user", __name__)
+user_schema = UserSchema()
+purchase_schema = PurchaseSchema(many=True)
+notification_schema = NotificationSchema(many=True)
+
+
+@user_bp.get("/me")
+@jwt_required()
+@user_active_required
+def get_profile():
+    return jsonify({"user": user_schema.dump(current_user)})
+
+
+@user_bp.put("/me")
+@jwt_required()
+@user_active_required
+def update_profile():
+    payload = request.get_json() or {}
+    full_name = payload.get("full_name")
+    tier = payload.get("tier")
+
+    if full_name is not None:
+        current_user.full_name = full_name
+
+    if tier in {tier.value for tier in SubscriptionTier}:
+        current_user.tier = tier
+
+    db.session.commit()
+    return jsonify({"message": "Profile updated", "user": user_schema.dump(current_user)})
+
+
+@user_bp.get("/purchases")
+@jwt_required()
+def purchases():
+    return jsonify({"purchases": purchase_schema.dump(current_user.purchases)})
+
+
+@user_bp.post("/progress")
+@jwt_required()
+@user_active_required
+def update_progress():
+    payload = request.get_json() or {}
+    lesson_id = payload.get("lesson_id")
+    completed = bool(payload.get("completed", True))
+
+    lesson = Lesson.query.get_or_404(lesson_id)
+
+    progress = LessonProgress.query.filter_by(
+        user_id=current_user.id, lesson_id=lesson.id
+    ).first()
+
+    if not progress:
+        progress = LessonProgress(user_id=current_user.id, lesson_id=lesson.id)
+        db.session.add(progress)
+
+    progress.completed = completed
+    progress.completed_at = datetime.utcnow() if completed else None
+    db.session.commit()
+
+    completed_count = LessonProgress.query.filter_by(
+        user_id=current_user.id, completed=True
+    ).count()
+    total_lessons = Lesson.query.count()
+    progress_percentage = (completed_count / total_lessons * 100) if total_lessons else 0
+
+    if progress_percentage >= 100:
+        send_email(
+            subject="Поздравляем с завершением курса!",
+            recipient=current_user.email,
+            body="Ваш сертификат готов. Загрузите его в личном кабинете.",
+        )
+
+    return jsonify(
+        {
+            "message": "Progress updated",
+            "progress_percentage": round(progress_percentage, 2),
+        }
+    )
+
+
+@user_bp.get("/notifications")
+@jwt_required()
+def list_notifications():
+    notifications = Notification.query.filter_by(user_id=current_user.id).order_by(
+        Notification.created_at.desc()
+    )
+    return jsonify({"notifications": notification_schema.dump(notifications)})
+
+
+@user_bp.post("/notifications/read")
+@jwt_required()
+def mark_notifications():
+    payload = request.get_json() or {}
+    notification_ids = payload.get("ids", [])
+
+    Notification.query.filter(
+        Notification.user_id == current_user.id,
+        Notification.id.in_(notification_ids),
+    ).update({"is_read": True}, synchronize_session=False)
+    db.session.commit()
+
+    return jsonify({"message": "Notifications updated"})
+

--- a/backend/schemas/course.py
+++ b/backend/schemas/course.py
@@ -1,0 +1,39 @@
+from marshmallow import Schema, fields
+
+
+class LessonSchema(Schema):
+    id = fields.Int(dump_only=True)
+    title = fields.Str()
+    order_index = fields.Int()
+    content = fields.Str()
+    video_url = fields.Str(allow_none=True)
+    estimated_minutes = fields.Int()
+    attachments = fields.Str(allow_none=True)
+
+
+class SectionSchema(Schema):
+    id = fields.Int(dump_only=True)
+    title = fields.Str()
+    order_index = fields.Int()
+    summary = fields.Str(allow_none=True)
+    lessons = fields.List(fields.Nested(LessonSchema))
+
+
+class ChapterSchema(Schema):
+    id = fields.Int(dump_only=True)
+    title = fields.Str()
+    order_index = fields.Int()
+    sections = fields.List(fields.Nested(SectionSchema))
+
+
+class CourseSchema(Schema):
+    id = fields.Int(dump_only=True)
+    title = fields.Str()
+    description = fields.Str()
+    level = fields.Str()
+    price = fields.Float()
+    is_active = fields.Bool()
+    hero_video_url = fields.Str(allow_none=True)
+    slug = fields.Str()
+    chapters = fields.List(fields.Nested(ChapterSchema))
+

--- a/backend/schemas/purchase.py
+++ b/backend/schemas/purchase.py
@@ -1,0 +1,11 @@
+from marshmallow import Schema, fields
+
+
+class PurchaseSchema(Schema):
+    id = fields.Int(dump_only=True)
+    course_id = fields.Int()
+    status = fields.Str()
+    tier = fields.Str()
+    created_at = fields.DateTime()
+    transaction_reference = fields.Str(allow_none=True)
+

--- a/backend/schemas/user.py
+++ b/backend/schemas/user.py
@@ -1,0 +1,22 @@
+from marshmallow import Schema, fields
+
+
+class UserSchema(Schema):
+    id = fields.Int(dump_only=True)
+    email = fields.Email(required=True)
+    full_name = fields.Str(allow_none=True)
+    status = fields.Str()
+    tier = fields.Str()
+    is_admin = fields.Bool()
+    created_at = fields.DateTime()
+    last_login_at = fields.DateTime(allow_none=True)
+
+
+class NotificationSchema(Schema):
+    id = fields.Int(dump_only=True)
+    title = fields.Str()
+    message = fields.Str()
+    category = fields.Str()
+    is_read = fields.Bool()
+    created_at = fields.DateTime()
+

--- a/backend/seed.py
+++ b/backend/seed.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from .extensions import bcrypt, db
+from .models import Chapter, Course, Lesson, Section, SubscriptionTier, User
+
+
+def seed_database() -> None:
+    admin = User.query.filter_by(email="admin@example.com").first()
+    if not admin:
+        admin = User(
+            email="admin@example.com",
+            full_name="Администратор",
+            is_admin=True,
+            tier=SubscriptionTier.PREMIUM.value,
+            password_hash=bcrypt.generate_password_hash("admin123").decode("utf-8"),
+        )
+        db.session.add(admin)
+
+    course = Course.query.filter_by(slug="python-mastery").first()
+    if not course:
+        course = Course(
+            title="Python Mastery",
+            slug="python-mastery",
+            description="Полный курс Python от нуля до уровня Middle",
+            level="beginner",
+            price=199.0,
+            hero_video_url="https://www.youtube.com/embed/rfscVS0vtbw",
+        )
+        db.session.add(course)
+        db.session.flush()
+
+        chapter1 = Chapter(title="Основы Python", order_index=1, course_id=course.id)
+        chapter2 = Chapter(title="Встроенные библиотеки", order_index=2, course_id=course.id)
+        db.session.add_all([chapter1, chapter2])
+        db.session.flush()
+
+        section1 = Section(
+            title="Переменные и типы данных",
+            order_index=1,
+            chapter_id=chapter1.id,
+            summary="Изучаем основы синтаксиса и типы данных",
+        )
+        section2 = Section(
+            title="Условные операторы",
+            order_index=2,
+            chapter_id=chapter1.id,
+            summary="if, elif, else",
+        )
+        section3 = Section(
+            title="Циклы",
+            order_index=3,
+            chapter_id=chapter1.id,
+            summary="for и while",
+        )
+        section4 = Section(
+            title="Работа с os и sys",
+            order_index=1,
+            chapter_id=chapter2.id,
+            summary="Автоматизация и окружение",
+        )
+        section5 = Section(
+            title="Модуль datetime",
+            order_index=2,
+            chapter_id=chapter2.id,
+            summary="Работа со временем",
+        )
+        section6 = Section(
+            title="Collections и itertools",
+            order_index=3,
+            chapter_id=chapter2.id,
+            summary="Мощные структуры данных",
+        )
+        db.session.add_all([section1, section2, section3, section4, section5, section6])
+        db.session.flush()
+
+        lessons = [
+            Lesson(
+                section_id=section1.id,
+                title="Введение в переменные",
+                order_index=1,
+                content="""<h2>Переменные</h2><p>В Python переменная создается при присвоении значения.</p><pre><code>name = 'Pythonist'</code></pre>""",
+                video_url="https://www.youtube.com/embed/_uQrJ0TkZlc",
+                attachments='["variables.pdf"]',
+            ),
+            Lesson(
+                section_id=section2.id,
+                title="Условные операторы",
+                order_index=1,
+                content="""<h2>if/else</h2><p>Примеры использования условий.</p><pre><code>if score &gt;= 90:\n    grade = 'A'</code></pre>""",
+                attachments='["conditions.ipynb"]',
+            ),
+            Lesson(
+                section_id=section3.id,
+                title="Циклы",
+                order_index=1,
+                content="""<h2>Циклы</h2><p>Циклы позволяют повторять действия.</p><pre><code>for item in items:\n    print(item)</code></pre>""",
+            ),
+            Lesson(
+                section_id=section4.id,
+                title="Работа с os и sys",
+                order_index=1,
+                content="""<h2>os и sys</h2><p>Путь к автоматизации.</p><pre><code>import os, sys</code></pre>""",
+            ),
+            Lesson(
+                section_id=section5.id,
+                title="Datetime основы",
+                order_index=1,
+                content="""<h2>datetime</h2><p>Даты и время.</p><pre><code>from datetime import datetime</code></pre>""",
+            ),
+            Lesson(
+                section_id=section6.id,
+                title="Collections и itertools",
+                order_index=1,
+                content="""<h2>collections</h2><p>Работаем с Counter.</p><pre><code>from collections import Counter</code></pre>""",
+            ),
+        ]
+        db.session.add_all(lessons)
+
+    db.session.commit()
+

--- a/backend/utils/decorators.py
+++ b/backend/utils/decorators.py
@@ -1,0 +1,28 @@
+from functools import wraps
+from typing import Callable
+
+from flask import abort
+from flask_jwt_extended import get_jwt
+
+
+def admin_required(func: Callable):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        claims = get_jwt()
+        if not claims.get("is_admin"):
+            abort(403, description="Administrator rights required")
+        return func(*args, **kwargs)
+
+    return wrapper
+
+
+def user_active_required(func: Callable):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        claims = get_jwt()
+        if claims.get("status") != "active":
+            abort(403, description="User account is blocked")
+        return func(*args, **kwargs)
+
+    return wrapper
+

--- a/backend/utils/email.py
+++ b/backend/utils/email.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Iterable
+
+from flask import current_app
+
+
+def send_email(subject: str, recipient: str, body: str) -> None:
+    """Lightweight email helper that logs outgoing messages."""
+    sender = current_app.config.get("MAIL_SENDER", "no-reply@example.com")
+    message = (
+        f"\n--- Email ---\n"
+        f"Time: {datetime.utcnow().isoformat()}\n"
+        f"From: {sender}\n"
+        f"To: {recipient}\n"
+        f"Subject: {subject}\n"
+        f"Body:\n{body}\n"
+        f"--- End Email ---"
+    )
+    if current_app.config.get("MAIL_SUPPRESS_SEND", True):
+        current_app.logger.info("Email suppressed: %s", message)
+    else:
+        # In production you would integrate Flask-Mail, Sendgrid etc.
+        current_app.logger.info("Email sent: %s", message)
+
+
+def send_bulk_email(subject: str, recipients: Iterable[str], body: str) -> None:
+    for recipient in recipients:
+        send_email(subject, recipient, body)
+

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="ru" class="scroll-smooth">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Python Mastery Platform</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fira+Sans:wght@400;600;700&family=Inter:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body class="bg-slate-100 dark:bg-slate-900">
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "python-course-platform",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@ckeditor/ckeditor5-build-classic": "^36.0.1",
+    "@ckeditor/ckeditor5-react": "^6.1.0",
+    "@headlessui/react": "^1.7.17",
+    "@heroicons/react": "^2.0.18",
+    "axios": "^1.5.0",
+    "classnames": "^2.3.2",
+    "framer-motion": "^10.16.4",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.15.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.21",
+    "@types/react-dom": "^18.2.7",
+    "@vitejs/plugin-react": "^4.0.4",
+    "autoprefixer": "^10.4.15",
+    "postcss": "^8.4.29",
+    "tailwindcss": "^3.3.3",
+    "vite": "^4.4.9"
+  }
+}

--- a/frontend/postcss.config.cjs
+++ b/frontend/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,64 @@
+import { Suspense, lazy } from 'react';
+import { Route, Routes } from 'react-router-dom';
+import Navbar from './components/Navbar';
+import Footer from './components/Footer';
+import LoadingOverlay from './components/LoadingOverlay';
+import ProtectedRoute from './components/ProtectedRoute';
+import { useAuth } from './context/AuthContext';
+
+const Home = lazy(() => import('./pages/Home'));
+const Login = lazy(() => import('./pages/Auth/Login'));
+const Register = lazy(() => import('./pages/Auth/Register'));
+const ForgotPassword = lazy(() => import('./pages/Auth/ForgotPassword'));
+const CourseOverview = lazy(() => import('./pages/Course/CourseOverview'));
+const LessonView = lazy(() => import('./pages/Course/LessonView'));
+const UserDashboard = lazy(() => import('./pages/Dashboard/UserDashboard'));
+const AdminDashboard = lazy(() => import('./pages/Admin/AdminDashboard'));
+
+function App() {
+  const { user } = useAuth();
+
+  return (
+    <div className="flex min-h-screen flex-col bg-slate-100 text-slate-900 transition-colors duration-500 dark:bg-slate-900 dark:text-slate-100">
+      <Navbar />
+      <main className="flex-1">
+        <Suspense fallback={<LoadingOverlay message="Загрузка контента..." />}>
+          <Routes>
+            <Route path="/" element={<Home />} />
+            <Route path="/login" element={<Login />} />
+            <Route path="/register" element={<Register />} />
+            <Route path="/forgot-password" element={<ForgotPassword />} />
+            <Route
+              path="/dashboard"
+              element={
+                <ProtectedRoute isAllowed={Boolean(user)} redirectTo="/login">
+                  <UserDashboard />
+                </ProtectedRoute>
+              }
+            />
+            <Route path="/course/:slug" element={<CourseOverview />} />
+            <Route
+              path="/course/:slug/lesson/:lessonId"
+              element={
+                <ProtectedRoute isAllowed={Boolean(user)} redirectTo="/login">
+                  <LessonView />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/admin/*"
+              element={
+                <ProtectedRoute isAllowed={Boolean(user?.is_admin)} redirectTo="/login">
+                  <AdminDashboard />
+                </ProtectedRoute>
+              }
+            />
+          </Routes>
+        </Suspense>
+      </main>
+      <Footer />
+    </div>
+  );
+}
+
+export default App;

--- a/frontend/src/components/CurriculumOverview.jsx
+++ b/frontend/src/components/CurriculumOverview.jsx
@@ -1,0 +1,65 @@
+import { motion } from 'framer-motion';
+
+const curriculum = [
+  {
+    title: 'Глава 1. Основы Python',
+    description: 'Синтаксис, работа с переменными, условиями и циклами',
+    sections: ['Переменные и типы данных', 'Условные операторы', 'Циклы и коллекции']
+  },
+  {
+    title: 'Глава 2. Встроенные библиотеки',
+    description: 'Практика с os, sys, datetime, collections и itertools',
+    sections: ['Работа с os и sys', 'Обработка дат и времени', 'Шаблоны итераций']
+  },
+  {
+    title: 'Глава 3. Практика и проекты',
+    description: 'Реализация веб-приложения, автоматизация и data pipelines',
+    sections: ['Flask + React', 'SQLAlchemy и PostgreSQL', 'CI/CD и деплой']
+  }
+];
+
+function CurriculumOverview() {
+  return (
+    <section id="curriculum" className="bg-slate-50 py-20 dark:bg-slate-950">
+      <div className="mx-auto max-w-6xl px-4 lg:px-8">
+        <div className="text-center">
+          <h2 className="text-3xl font-bold sm:text-4xl">Программа курса</h2>
+          <p className="mt-3 text-slate-600 dark:text-slate-300">
+            Структурированный путь от основ до уверенного владения Python и популярными библиотеками.
+          </p>
+        </div>
+        <div className="mt-12 grid gap-8 md:grid-cols-3">
+          {curriculum.map((chapter, index) => (
+            <motion.div
+              key={chapter.title}
+              className="glass-panel card-hover flex h-full flex-col rounded-3xl p-6"
+              initial={{ opacity: 0, y: 40 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true }}
+              transition={{ delay: index * 0.1 }}
+            >
+              <div className="flex items-start gap-3">
+                <span className="flex h-10 w-10 items-center justify-center rounded-2xl bg-primary/10 text-lg font-bold text-primary">
+                  {index + 1}
+                </span>
+                <div>
+                  <h3 className="text-xl font-semibold">{chapter.title}</h3>
+                  <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">{chapter.description}</p>
+                </div>
+              </div>
+              <ul className="mt-6 flex flex-1 flex-col gap-3 text-sm text-slate-600 dark:text-slate-300">
+                {chapter.sections.map((section) => (
+                  <li key={section} className="rounded-2xl bg-white/80 px-4 py-3 dark:bg-slate-800/60">
+                    {section}
+                  </li>
+                ))}
+              </ul>
+            </motion.div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default CurriculumOverview;

--- a/frontend/src/components/FAQAccordion.jsx
+++ b/frontend/src/components/FAQAccordion.jsx
@@ -1,0 +1,51 @@
+import { Disclosure } from '@headlessui/react';
+import { ChevronDownIcon } from '@heroicons/react/24/outline';
+
+const faqs = [
+  {
+    question: 'Нужен ли опыт программирования для старта?',
+    answer: 'Нет, курс начинается с самых основ. Вы получите все необходимые материалы и поддержку менторов.'
+  },
+  {
+    question: 'Как реализована практика?',
+    answer: 'Каждый модуль завершается проектом. Вы будете работать с реальными кейсами и сдавать их на проверку наставникам.'
+  },
+  {
+    question: 'Предусмотрены ли сертификаты?',
+    answer: 'После прохождения курса и финального проекта вы получаете именной сертификат и карьерную консультацию.'
+  }
+];
+
+function FAQAccordion() {
+  return (
+    <section id="faq" className="bg-white py-20 dark:bg-slate-900">
+      <div className="mx-auto max-w-4xl px-4 lg:px-0">
+        <div className="text-center">
+          <h2 className="text-3xl font-bold">Частые вопросы</h2>
+          <p className="mt-3 text-slate-600 dark:text-slate-300">Ответы на популярные вопросы о программе и обучении.</p>
+        </div>
+        <div className="mt-10 space-y-4">
+          {faqs.map((faq) => (
+            <Disclosure key={faq.question}>
+              {({ open }) => (
+                <div className="glass-panel rounded-3xl">
+                  <Disclosure.Button className="flex w-full items-center justify-between px-6 py-5 text-left text-sm font-semibold">
+                    {faq.question}
+                    <ChevronDownIcon
+                      className={`h-5 w-5 transition-transform ${open ? 'rotate-180 text-primary' : 'text-slate-400'}`}
+                    />
+                  </Disclosure.Button>
+                  <Disclosure.Panel className="px-6 pb-5 text-sm text-slate-600 dark:text-slate-300">
+                    {faq.answer}
+                  </Disclosure.Panel>
+                </div>
+              )}
+            </Disclosure>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default FAQAccordion;

--- a/frontend/src/components/FeatureHighlights.jsx
+++ b/frontend/src/components/FeatureHighlights.jsx
@@ -1,0 +1,47 @@
+import { motion } from 'framer-motion';
+import { CommandLineIcon, CubeIcon, AcademicCapIcon } from '@heroicons/react/24/outline';
+
+const features = [
+  {
+    title: 'Практика на реальных проектах',
+    description: 'От автоматизации с os и sys до построения REST API на Flask с SQLAlchemy.',
+    icon: CommandLineIcon
+  },
+  {
+    title: 'Встроенные библиотеки Python',
+    description: 'Детальные модули по datetime, collections, itertools с практическими кейсами.',
+    icon: CubeIcon
+  },
+  {
+    title: 'Карьерное сопровождение',
+    description: 'Подготовка к собеседованиям, ревью резюме и доступ к закрытым вакансиям.',
+    icon: AcademicCapIcon
+  }
+];
+
+function FeatureHighlights() {
+  return (
+    <section className="bg-white py-20 dark:bg-slate-900">
+      <div className="mx-auto max-w-6xl px-4 lg:px-8">
+        <div className="grid gap-10 lg:grid-cols-3">
+          {features.map((feature, index) => (
+            <motion.div
+              key={feature.title}
+              className="glass-panel card-hover rounded-3xl p-8"
+              initial={{ opacity: 0, y: 20 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true }}
+              transition={{ delay: index * 0.1 }}
+            >
+              <feature.icon className="h-10 w-10 text-primary" />
+              <h3 className="mt-5 text-xl font-semibold">{feature.title}</h3>
+              <p className="mt-3 text-sm text-slate-600 dark:text-slate-300">{feature.description}</p>
+            </motion.div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default FeatureHighlights;

--- a/frontend/src/components/Footer.jsx
+++ b/frontend/src/components/Footer.jsx
@@ -1,0 +1,52 @@
+import { Link } from 'react-router-dom';
+import { motion } from 'framer-motion';
+
+function Footer() {
+  return (
+    <footer className="border-t border-slate-200 bg-white/70 py-10 dark:border-slate-800 dark:bg-slate-900/70">
+      <div className="mx-auto grid max-w-6xl gap-8 px-4 md:grid-cols-2 lg:grid-cols-4 lg:px-8">
+        <div>
+          <h3 className="text-lg font-semibold">Python Mastery</h3>
+          <p className="mt-3 text-sm text-slate-600 dark:text-slate-400">
+            Современная платформа обучения Python с проектами, наставниками и комьюнити.
+          </p>
+        </div>
+        <div>
+          <h4 className="text-sm font-semibold uppercase text-slate-500">Навигация</h4>
+          <ul className="mt-3 space-y-2 text-sm text-slate-600 dark:text-slate-400">
+            <li><Link to="/#curriculum">Программа курса</Link></li>
+            <li><Link to="/#pricing">Тарифы</Link></li>
+            <li><Link to="/#faq">FAQ</Link></li>
+          </ul>
+        </div>
+        <div>
+          <h4 className="text-sm font-semibold uppercase text-slate-500">Контакты</h4>
+          <p className="mt-3 text-sm text-slate-600 dark:text-slate-400">support@pythonmastery.com</p>
+          <p className="text-sm text-slate-600 dark:text-slate-400">+7 (900) 123-45-67</p>
+        </div>
+        <motion.div
+          className="rounded-3xl bg-gradient-to-br from-primary/20 via-accent/20 to-primary/10 p-6"
+          initial={{ opacity: 0, y: 30 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+        >
+          <h4 className="text-lg font-semibold">Готовы стать Middle разработчиком?</h4>
+          <p className="mt-2 text-sm text-slate-700 dark:text-slate-300">
+            Получите доступ к более чем 120 урокам, лайв-сессиям и карьерному сопровождению.
+          </p>
+          <Link
+            to="/register"
+            className="mt-4 inline-flex w-full items-center justify-center rounded-2xl bg-primary px-4 py-2 text-sm font-semibold text-white shadow-lg transition hover:bg-primary/80"
+          >
+            Присоединиться
+          </Link>
+        </motion.div>
+      </div>
+      <p className="mt-10 text-center text-xs text-slate-500">
+        © {new Date().getFullYear()} Python Mastery. Все права защищены.
+      </p>
+    </footer>
+  );
+}
+
+export default Footer;

--- a/frontend/src/components/Hero.jsx
+++ b/frontend/src/components/Hero.jsx
@@ -1,0 +1,78 @@
+import { motion } from 'framer-motion';
+import { Link } from 'react-router-dom';
+
+function Hero() {
+  return (
+    <section className="relative overflow-hidden bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 py-20 text-white">
+      <div className="absolute inset-0 opacity-50">
+        <video
+          className="h-full w-full object-cover"
+          autoPlay
+          loop
+          muted
+          playsInline
+          poster="https://images.unsplash.com/photo-1517433456452-f9633a875f6f?auto=format&fit=crop&w=1400&q=80"
+        >
+          <source src="https://storage.googleapis.com/coverr-main/mp4/Mt_Baker.mp4" type="video/mp4" />
+        </video>
+      </div>
+      <div className="absolute inset-0 bg-gradient-to-r from-slate-900/80 via-slate-900/60 to-slate-900/80"></div>
+      <div className="relative mx-auto flex max-w-6xl flex-col gap-16 px-4 lg:flex-row lg:items-center lg:px-8">
+        <motion.div
+          className="glass-panel w-full max-w-2xl rounded-3xl bg-white/10 p-10 text-left"
+          initial={{ opacity: 0, y: 40 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.8 }}
+        >
+          <p className="text-sm font-semibold uppercase tracking-widest text-primary">Python Middle за 6 месяцев</p>
+          <h1 className="mt-4 text-4xl font-bold leading-tight sm:text-5xl">
+            Пройди путь от нуля до уверенного уровня Middle-разработчика
+          </h1>
+          <p className="mt-6 text-lg text-slate-200">
+            Глубокое изучение Python, автоматизации, веб-разработки, встроенных библиотек и 5 практических проектов с менторской поддержкой.
+          </p>
+          <div className="mt-10 flex flex-wrap items-center gap-4">
+            <Link
+              to="/register"
+              className="rounded-full bg-primary px-6 py-3 text-sm font-semibold text-white shadow-xl transition hover:bg-primary/80"
+            >
+              Начать обучение
+            </Link>
+            <a
+              href="#curriculum"
+              className="rounded-full border border-white/40 px-6 py-3 text-sm font-semibold text-white transition hover:border-primary hover:text-primary"
+            >
+              Смотреть программу
+            </a>
+          </div>
+          <div className="mt-10 grid gap-4 sm:grid-cols-3">
+            {["120+ уроков", "5 pet-проектов", "Карьерный трек"].map((item) => (
+              <div key={item} className="rounded-2xl bg-white/10 p-4 text-sm font-semibold text-slate-200">
+                {item}
+              </div>
+            ))}
+          </div>
+        </motion.div>
+        <motion.div
+          className="glass-panel w-full rounded-3xl bg-white/10 p-6"
+          initial={{ opacity: 0, scale: 0.9 }}
+          animate={{ opacity: 1, scale: 1 }}
+          transition={{ duration: 0.8, delay: 0.2 }}
+        >
+          <iframe
+            className="aspect-video w-full rounded-2xl"
+            src="https://www.youtube.com/embed/rfscVS0vtbw"
+            title="Python Course Preview"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+            allowFullScreen
+          ></iframe>
+          <p className="mt-4 text-sm text-slate-200">
+            Посмотри вводный урок и узнай, как устроена платформа обучения.
+          </p>
+        </motion.div>
+      </div>
+    </section>
+  );
+}
+
+export default Hero;

--- a/frontend/src/components/LoadingOverlay.jsx
+++ b/frontend/src/components/LoadingOverlay.jsx
@@ -1,0 +1,18 @@
+import { motion } from 'framer-motion';
+
+function LoadingOverlay({ message = 'Загрузка...' }) {
+  return (
+    <div className="flex h-full w-full items-center justify-center py-20">
+      <motion.div
+        className="flex flex-col items-center gap-4"
+        animate={{ opacity: [0.4, 1, 0.4] }}
+        transition={{ repeat: Infinity, duration: 1.8 }}
+      >
+        <div className="h-14 w-14 animate-spin rounded-full border-4 border-primary border-t-transparent"></div>
+        <p className="text-sm font-medium text-slate-600 dark:text-slate-300">{message}</p>
+      </motion.div>
+    </div>
+  );
+}
+
+export default LoadingOverlay;

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -1,0 +1,143 @@
+import { useState } from 'react';
+import { Link, NavLink, useNavigate } from 'react-router-dom';
+import { Bars3Icon, XMarkIcon } from '@heroicons/react/24/outline';
+import ThemeToggle from './ThemeToggle';
+import { useAuth } from '../context/AuthContext';
+
+const navItems = [
+  { to: '/', label: 'Главная', exact: true },
+  { to: '/#curriculum', label: 'Программа' },
+  { to: '/#pricing', label: 'Подписки' },
+  { to: '/#reviews', label: 'Отзывы' }
+];
+
+function Navbar() {
+  const [open, setOpen] = useState(false);
+  const navigate = useNavigate();
+  const { user, logout } = useAuth();
+
+  const handleLogout = () => {
+    logout();
+    navigate('/');
+  };
+
+  return (
+    <header className="sticky top-0 z-50 backdrop-blur supports-[backdrop-filter]:bg-white/60 dark:supports-[backdrop-filter]:bg-slate-900/60">
+      <nav className="mx-auto flex max-w-6xl items-center justify-between px-4 py-3 lg:px-8">
+        <Link to="/" className="flex items-center gap-2 text-xl font-semibold">
+          <span className="flex h-9 w-9 items-center justify-center rounded-2xl bg-gradient-to-br from-primary to-accent text-white shadow-lg">
+            Py
+          </span>
+          Python Mastery
+        </Link>
+        <div className="flex items-center gap-3 lg:hidden">
+          <ThemeToggle />
+          <button
+            onClick={() => setOpen((prev) => !prev)}
+            className="rounded-full p-2 text-slate-600 transition hover:bg-slate-200 dark:text-slate-100 dark:hover:bg-slate-800"
+            aria-label="Toggle navigation"
+          >
+            {open ? <XMarkIcon className="h-6 w-6" /> : <Bars3Icon className="h-6 w-6" />}
+          </button>
+        </div>
+        <div className="hidden items-center gap-6 lg:flex">
+          {navItems.map((item) => (
+            <NavLink
+              key={item.to}
+              to={item.to}
+              className={({ isActive }) =>
+                `text-sm font-medium transition hover:text-primary ${isActive ? 'text-primary' : 'text-slate-600 dark:text-slate-300'}`
+              }
+            >
+              {item.label}
+            </NavLink>
+          ))}
+          <ThemeToggle />
+          {user ? (
+            <div className="flex items-center gap-3">
+              <Link
+                to={user.is_admin ? '/admin' : '/dashboard'}
+                className="rounded-full bg-primary px-4 py-2 text-sm font-semibold text-white shadow-lg transition hover:bg-primary/80"
+              >
+                Кабинет
+              </Link>
+              <button
+                onClick={handleLogout}
+                className="rounded-full border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-600 transition hover:border-primary hover:text-primary dark:border-slate-600 dark:text-slate-200"
+              >
+                Выйти
+              </button>
+            </div>
+          ) : (
+            <div className="flex items-center gap-3">
+              <Link to="/login" className="text-sm font-semibold text-slate-600 transition hover:text-primary dark:text-slate-200">
+                Вход
+              </Link>
+              <Link
+                to="/register"
+                className="rounded-full bg-primary px-4 py-2 text-sm font-semibold text-white shadow-lg transition hover:bg-primary/80"
+              >
+                Начать обучение
+              </Link>
+            </div>
+          )}
+        </div>
+      </nav>
+      {open && (
+        <div className="lg:hidden">
+          <div className="glass-panel mx-4 mb-4 space-y-3 p-4">
+            {navItems.map((item) => (
+              <Link
+                key={item.to}
+                to={item.to}
+                className="block rounded-xl px-3 py-2 text-sm font-semibold text-slate-700 transition hover:bg-slate-100 dark:text-slate-200 dark:hover:bg-slate-800"
+                onClick={() => setOpen(false)}
+              >
+                {item.label}
+              </Link>
+            ))}
+            {user ? (
+              <div className="flex items-center gap-2">
+                <Link
+                  to={user.is_admin ? '/admin' : '/dashboard'}
+                  className="flex-1 rounded-xl bg-primary px-3 py-2 text-center text-sm font-semibold text-white"
+                  onClick={() => setOpen(false)}
+                >
+                  Кабинет
+                </Link>
+                <button
+                  onClick={() => {
+                    handleLogout();
+                    setOpen(false);
+                  }}
+                  className="flex-1 rounded-xl border border-slate-300 px-3 py-2 text-sm font-semibold text-slate-700 transition hover:border-primary hover:text-primary dark:border-slate-600 dark:text-slate-200"
+                >
+                  Выйти
+                </button>
+              </div>
+            ) : (
+              <div className="flex items-center gap-2">
+                <Link
+                  to="/login"
+                  className="flex-1 rounded-xl bg-slate-200 px-3 py-2 text-center text-sm font-semibold text-slate-700 transition hover:bg-slate-300 dark:bg-slate-700 dark:text-slate-100"
+                  onClick={() => setOpen(false)}
+                >
+                  Вход
+                </Link>
+                <Link
+                  to="/register"
+                  className="flex-1 rounded-xl bg-primary px-3 py-2 text-center text-sm font-semibold text-white"
+                  onClick={() => setOpen(false)}
+                >
+                  Регистрация
+                </Link>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </header>
+  );
+}
+
+export default Navbar;

--- a/frontend/src/components/ProtectedRoute.jsx
+++ b/frontend/src/components/ProtectedRoute.jsx
@@ -1,0 +1,13 @@
+import { Navigate, useLocation } from 'react-router-dom';
+
+function ProtectedRoute({ isAllowed, redirectTo = '/login', children }) {
+  const location = useLocation();
+
+  if (!isAllowed) {
+    return <Navigate to={redirectTo} state={{ from: location }} replace />;
+  }
+
+  return children;
+}
+
+export default ProtectedRoute;

--- a/frontend/src/components/SubscriptionPlans.jsx
+++ b/frontend/src/components/SubscriptionPlans.jsx
@@ -1,0 +1,86 @@
+import { motion } from 'framer-motion';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+
+const plans = [
+  {
+    name: 'Базовый',
+    description: 'Доступ к основным урокам и практическим заданиям',
+    price: '990₽ / мес',
+    features: ['Основы синтаксиса', 'Практикум по алгоритмам', 'Чат студентов'],
+    tier: 'basic'
+  },
+  {
+    name: 'Премиум',
+    description: 'Полный курс, проекты и карьерное сопровождение',
+    price: '2 990₽ / мес',
+    features: ['Встроенные библиотеки', '5 pet-проектов', 'Наставник и карьерный трек'],
+    tier: 'premium',
+    highlight: true
+  }
+];
+
+function SubscriptionPlans({ onSelect }) {
+  const navigate = useNavigate();
+  const { user } = useAuth();
+
+  const handleSelect = (plan) => {
+    if (!user) {
+      navigate('/register');
+      return;
+    }
+    onSelect?.(plan);
+  };
+
+  return (
+    <section id="pricing" className="bg-white py-20 dark:bg-slate-900">
+      <div className="mx-auto max-w-6xl px-4 lg:px-8">
+        <div className="text-center">
+          <h2 className="text-3xl font-bold sm:text-4xl">Выбери оптимальную подписку</h2>
+          <p className="mt-3 text-slate-600 dark:text-slate-300">
+            Гибкие тарифы для разных целей — от изучения основ до подготовки к позиции Middle-разработчика.
+          </p>
+        </div>
+        <div className="mt-12 grid gap-8 md:grid-cols-2">
+          {plans.map((plan) => (
+            <motion.div
+              key={plan.name}
+              className={`glass-panel card-hover relative flex flex-col rounded-3xl p-8 ${
+                plan.highlight ? 'border-primary shadow-2xl' : ''
+              }`}
+              initial={{ opacity: 0, y: 40 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true }}
+              transition={{ duration: 0.5 }}
+            >
+              {plan.highlight && (
+                <span className="absolute right-6 top-6 rounded-full bg-primary/20 px-4 py-1 text-xs font-semibold text-primary">
+                  Популярно
+                </span>
+              )}
+              <h3 className="text-2xl font-semibold">{plan.name}</h3>
+              <p className="mt-3 text-sm text-slate-600 dark:text-slate-300">{plan.description}</p>
+              <p className="mt-6 text-4xl font-bold text-slate-900 dark:text-white">{plan.price}</p>
+              <ul className="mt-8 space-y-3 text-sm text-slate-600 dark:text-slate-200">
+                {plan.features.map((feature) => (
+                  <li key={feature} className="flex items-center gap-2">
+                    <span className="h-2 w-2 rounded-full bg-primary"></span>
+                    {feature}
+                  </li>
+                ))}
+              </ul>
+              <button
+                onClick={() => handleSelect(plan)}
+                className="mt-10 inline-flex items-center justify-center rounded-full bg-primary px-6 py-3 text-sm font-semibold text-white shadow-xl transition hover:bg-primary/80"
+              >
+                {user ? 'Выбрать план' : 'Зарегистрироваться'}
+              </button>
+            </motion.div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default SubscriptionPlans;

--- a/frontend/src/components/TestimonialCarousel.jsx
+++ b/frontend/src/components/TestimonialCarousel.jsx
@@ -1,0 +1,71 @@
+import { useEffect, useState } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+
+const testimonials = [
+  {
+    name: 'Мария Иванова',
+    role: 'Python Developer в FinTech',
+    quote: 'Благодаря проектам по автоматизации и практическим задачам я получила оффер на позицию Middle уже через 5 месяцев обучения.'
+  },
+  {
+    name: 'Илья Смирнов',
+    role: 'Backend Engineer в стартапе',
+    quote: 'Курс помог мне глубоко понять встроенные библиотеки Python. Особенно полезными оказались уроки по collections и itertools.'
+  },
+  {
+    name: 'Алина Петрова',
+    role: 'Data Engineer',
+    quote: 'Понравились проекты с SQLAlchemy и автоматизацией. Поддержка наставников и комьюнити мотивирует двигаться вперед.'
+  }
+];
+
+function TestimonialCarousel() {
+  const [index, setIndex] = useState(0);
+
+  useEffect(() => {
+    const timer = setInterval(() => setIndex((prev) => (prev + 1) % testimonials.length), 8000);
+    return () => clearInterval(timer);
+  }, []);
+
+  return (
+    <section id="reviews" className="bg-gradient-to-br from-slate-900 to-slate-800 py-20 text-white">
+      <div className="mx-auto max-w-4xl px-4 text-center">
+        <h2 className="text-3xl font-bold">Отзывы выпускников</h2>
+        <p className="mt-3 text-slate-300">
+          Истории студентов, которые прошли путь до уровня Middle и устроились в компании мечты.
+        </p>
+        <div className="relative mt-10 overflow-hidden rounded-3xl bg-white/10 p-10">
+          <AnimatePresence mode="wait">
+            <motion.div
+              key={testimonials[index].name}
+              initial={{ opacity: 0, y: 30 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -30 }}
+              transition={{ duration: 0.6 }}
+            >
+              <p className="text-lg leading-relaxed text-slate-200">“{testimonials[index].quote}”</p>
+              <div className="mt-6 text-sm font-semibold">
+                {testimonials[index].name}
+                <span className="ml-2 font-normal text-slate-400">— {testimonials[index].role}</span>
+              </div>
+            </motion.div>
+          </AnimatePresence>
+          <div className="mt-8 flex justify-center gap-2">
+            {testimonials.map((_, dotIndex) => (
+              <button
+                key={dotIndex}
+                onClick={() => setIndex(dotIndex)}
+                className={`h-2 w-8 rounded-full transition ${
+                  dotIndex === index ? 'bg-primary' : 'bg-white/30 hover:bg-white/60'
+                }`}
+                aria-label={`Показать отзыв ${dotIndex + 1}`}
+              ></button>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default TestimonialCarousel;

--- a/frontend/src/components/ThemeToggle.jsx
+++ b/frontend/src/components/ThemeToggle.jsx
@@ -1,0 +1,18 @@
+import { MoonIcon, SunIcon } from '@heroicons/react/24/solid';
+import { useTheme } from '../context/ThemeContext';
+
+function ThemeToggle() {
+  const { theme, toggleTheme } = useTheme();
+
+  return (
+    <button
+      onClick={toggleTheme}
+      className="rounded-full border border-transparent bg-white/60 p-2 text-slate-600 shadow-lg transition hover:border-primary hover:text-primary dark:bg-slate-800/60 dark:text-slate-100"
+      aria-label="Toggle theme"
+    >
+      {theme === 'dark' ? <SunIcon className="h-5 w-5" /> : <MoonIcon className="h-5 w-5" />}
+    </button>
+  );
+}
+
+export default ThemeToggle;

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -1,0 +1,93 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import api from '../services/api';
+
+const AuthContext = createContext(null);
+
+const ACCESS_TOKEN_KEY = 'python_mastery_access';
+const REFRESH_TOKEN_KEY = 'python_mastery_refresh';
+const USER_KEY = 'python_mastery_user';
+
+export function AuthProvider({ children }) {
+  const [user, setUser] = useState(() => {
+    const raw = localStorage.getItem(USER_KEY);
+    return raw ? JSON.parse(raw) : null;
+  });
+  const [isLoading, setIsLoading] = useState(false);
+
+  const persistSession = useCallback((payload) => {
+    if (payload?.access_token) {
+      localStorage.setItem(ACCESS_TOKEN_KEY, payload.access_token);
+      api.defaults.headers.common.Authorization = `Bearer ${payload.access_token}`;
+    }
+    if (payload?.refresh_token) {
+      localStorage.setItem(REFRESH_TOKEN_KEY, payload.refresh_token);
+    }
+    if (payload?.user) {
+      setUser(payload.user);
+      localStorage.setItem(USER_KEY, JSON.stringify(payload.user));
+    }
+  }, []);
+
+  useEffect(() => {
+    const token = localStorage.getItem(ACCESS_TOKEN_KEY);
+    if (token) {
+      api.defaults.headers.common.Authorization = `Bearer ${token}`;
+    }
+  }, []);
+
+  const login = useCallback(async (credentials) => {
+    setIsLoading(true);
+    try {
+      const { data } = await api.post('/auth/login', credentials);
+      persistSession(data);
+      return data;
+    } finally {
+      setIsLoading(false);
+    }
+  }, [persistSession]);
+
+  const register = useCallback(async (payload) => {
+    setIsLoading(true);
+    try {
+      const { data } = await api.post('/auth/register', payload);
+      persistSession(data);
+      return data;
+    } finally {
+      setIsLoading(false);
+    }
+  }, [persistSession]);
+
+  const logout = useCallback(() => {
+    setUser(null);
+    localStorage.removeItem(ACCESS_TOKEN_KEY);
+    localStorage.removeItem(REFRESH_TOKEN_KEY);
+    localStorage.removeItem(USER_KEY);
+    delete api.defaults.headers.common.Authorization;
+  }, []);
+
+  const refreshProfile = useCallback(async () => {
+    const { data } = await api.get('/user/me');
+    setUser(data.user);
+    localStorage.setItem(USER_KEY, JSON.stringify(data.user));
+    return data.user;
+  }, []);
+
+  const value = useMemo(() => ({
+    user,
+    isLoading,
+    login,
+    register,
+    logout,
+    refreshProfile
+  }), [user, isLoading, login, register, logout, refreshProfile]);
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export function useAuth() {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuth must be used within AuthProvider');
+  }
+  return context;
+}

--- a/frontend/src/context/ThemeContext.jsx
+++ b/frontend/src/context/ThemeContext.jsx
@@ -1,0 +1,32 @@
+import { createContext, useContext, useEffect, useMemo, useState } from 'react';
+
+const ThemeContext = createContext(null);
+const THEME_KEY = 'python_mastery_theme';
+
+export function ThemeProvider({ children }) {
+  const [theme, setTheme] = useState(() => localStorage.getItem(THEME_KEY) || 'light');
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (theme === 'dark') {
+      root.classList.add('dark');
+    } else {
+      root.classList.remove('dark');
+    }
+    localStorage.setItem(THEME_KEY, theme);
+  }, [theme]);
+
+  const toggleTheme = () => setTheme((prev) => (prev === 'dark' ? 'light' : 'dark'));
+
+  const value = useMemo(() => ({ theme, toggleTheme }), [theme]);
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+}
+
+export function useTheme() {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error('useTheme must be used within ThemeProvider');
+  }
+  return context;
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,29 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+html, body, #root {
+  height: 100%;
+}
+
+body {
+  @apply font-body text-slate-800 dark:text-slate-100 bg-slate-100 dark:bg-slate-900 antialiased;
+}
+
+::-webkit-scrollbar {
+  width: 8px;
+}
+
+::-webkit-scrollbar-thumb {
+  background: linear-gradient(180deg, #38bdf8, #f97316);
+  border-radius: 9999px;
+}
+
+.glass-panel {
+  @apply bg-white/70 dark:bg-slate-800/70 backdrop-blur rounded-3xl shadow-glass border border-white/40 dark:border-slate-700/40;
+}
+
+.card-hover {
+  @apply transition-transform duration-300 hover:-translate-y-1 hover:shadow-xl;
+}
+

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App';
+import './index.css';
+import { AuthProvider } from './context/AuthContext';
+import { ThemeProvider } from './context/ThemeContext';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <ThemeProvider>
+        <AuthProvider>
+          <App />
+        </AuthProvider>
+      </ThemeProvider>
+    </BrowserRouter>
+  </React.StrictMode>
+);

--- a/frontend/src/pages/Admin/AdminDashboard.jsx
+++ b/frontend/src/pages/Admin/AdminDashboard.jsx
@@ -1,0 +1,49 @@
+import { NavLink, Route, Routes } from 'react-router-dom';
+import UserManagement from './UserManagement';
+import CourseManagement from './CourseManagement';
+
+function AdminDashboard() {
+  return (
+    <div className="bg-slate-50 py-16 dark:bg-slate-950">
+      <div className="mx-auto max-w-6xl px-4 lg:px-8">
+        <div className="glass-panel rounded-3xl p-8">
+          <h1 className="text-3xl font-bold">Админ-панель</h1>
+          <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">
+            Управляйте пользователями, контентом и аналитикой курса.
+          </p>
+          <div className="mt-6 flex flex-wrap gap-3">
+            <NavLink
+              to="users"
+              className={({ isActive }) =>
+                `rounded-full px-5 py-2 text-sm font-semibold transition ${
+                  isActive ? 'bg-primary text-white shadow-lg' : 'bg-white/70 text-slate-700 dark:bg-slate-800/70 dark:text-slate-200'
+                }`
+              }
+            >
+              Пользователи
+            </NavLink>
+            <NavLink
+              to="courses"
+              className={({ isActive }) =>
+                `rounded-full px-5 py-2 text-sm font-semibold transition ${
+                  isActive ? 'bg-primary text-white shadow-lg' : 'bg-white/70 text-slate-700 dark:bg-slate-800/70 dark:text-slate-200'
+                }`
+              }
+            >
+              Курсы
+            </NavLink>
+          </div>
+          <div className="mt-8">
+            <Routes>
+              <Route path="users" element={<UserManagement />} />
+              <Route path="courses" element={<CourseManagement />} />
+              <Route path="*" element={<UserManagement />} />
+            </Routes>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default AdminDashboard;

--- a/frontend/src/pages/Admin/CourseManagement.jsx
+++ b/frontend/src/pages/Admin/CourseManagement.jsx
@@ -1,0 +1,157 @@
+import { useEffect, useState } from 'react';
+import { CKEditor } from '@ckeditor/ckeditor5-react';
+import ClassicEditor from '@ckeditor/ckeditor5-build-classic';
+import { createChapter, createCourse, createLesson, createSection, previewContent } from '../../services/adminService';
+import { fetchCourse } from '../../services/courseService';
+
+function CourseManagement() {
+  const [course, setCourse] = useState(null);
+  const [content, setContent] = useState('<p>Новый урок</p>');
+  const [preview, setPreview] = useState('');
+  const [newLesson, setNewLesson] = useState({ title: '', video_url: '', estimated_minutes: 15 });
+  const [selectedSection, setSelectedSection] = useState(null);
+  const [status, setStatus] = useState('');
+  const [chapterTitle, setChapterTitle] = useState('');
+
+  const loadCourse = () => {
+    fetchCourse('python-mastery').then(({ data }) => {
+      setCourse(data.course);
+      if (data.course?.chapters?.[0]?.sections?.[0]) {
+        setSelectedSection(data.course.chapters[0].sections[0]);
+      }
+    });
+  };
+
+  useEffect(() => {
+    loadCourse();
+  }, []);
+
+  const handleCreateLesson = async () => {
+    if (!selectedSection) return;
+    await createLesson(selectedSection.id, { ...newLesson, content });
+    setStatus('Урок добавлен!');
+    setNewLesson({ title: '', video_url: '', estimated_minutes: 15 });
+    loadCourse();
+  };
+
+  const handlePreview = async () => {
+    const { data } = await previewContent({ content });
+    setPreview(data.preview);
+  };
+
+  return (
+    <div className="grid gap-8 lg:grid-cols-[1.2fr,1fr]">
+      <div className="space-y-6">
+        <div className="glass-panel rounded-3xl p-6">
+          <h2 className="text-xl font-semibold">Структура курса</h2>
+          <div className="mt-4 flex flex-wrap gap-3">
+            <button
+              onClick={() => createCourse({ title: 'Новый курс', slug: `course-${Date.now()}` }).then(() => loadCourse())}
+              className="rounded-full border border-primary px-4 py-2 text-sm font-semibold text-primary transition hover:bg-primary/10"
+            >
+              Создать курс
+            </button>
+            <div className="flex items-center gap-2">
+              <input
+                value={chapterTitle}
+                onChange={(event) => setChapterTitle(event.target.value)}
+                placeholder="Новая глава"
+                className="w-40 rounded-2xl border border-slate-200 bg-white px-3 py-2 text-xs shadow-inner transition focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20 dark:border-slate-700 dark:bg-slate-900"
+              />
+              <button
+                onClick={() =>
+                  course &&
+                  createChapter(course.id, { title: chapterTitle || 'Новая глава' }).then(() => {
+                    setStatus('Глава добавлена!');
+                    setChapterTitle('');
+                    loadCourse();
+                  })
+                }
+                disabled={!course}
+                className="rounded-full border border-slate-200 px-3 py-2 text-xs font-semibold text-slate-700 transition hover:border-primary hover:text-primary disabled:cursor-not-allowed disabled:opacity-60 dark:border-slate-600 dark:text-slate-200"
+              >
+                + Глава
+              </button>
+            </div>
+          </div>
+          <div className="mt-6 space-y-4">
+            {course?.chapters?.map((chapter) => (
+              <div key={chapter.id} className="rounded-3xl bg-slate-100/80 p-4 dark:bg-slate-800/60">
+                <div className="flex items-center justify-between">
+                  <h3 className="text-base font-semibold">{chapter.title}</h3>
+                  <button
+                    onClick={() =>
+                      createSection(chapter.id, { title: 'Новый раздел' }).then(() => {
+                        setStatus('Раздел добавлен!');
+                        loadCourse();
+                      })
+                    }
+                    className="rounded-full border border-slate-200 px-3 py-1 text-xs text-slate-700 transition hover:border-primary hover:text-primary dark:border-slate-600 dark:text-slate-200"
+                  >
+                    + Раздел
+                  </button>
+                </div>
+                <div className="mt-3 space-y-2">
+                  {chapter.sections.map((section) => (
+                    <button
+                      key={section.id}
+                      onClick={() => setSelectedSection(section)}
+                      className={`block w-full rounded-2xl px-3 py-2 text-left text-sm transition ${
+                        selectedSection?.id === section.id
+                          ? 'bg-primary/10 text-primary'
+                          : 'bg-white/80 text-slate-700 dark:bg-slate-900/40 dark:text-slate-200'
+                      }`}
+                    >
+                      {section.title}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+        {status && <p className="rounded-2xl bg-emerald-500/10 px-4 py-3 text-sm text-emerald-600 dark:text-emerald-400">{status}</p>}
+      </div>
+      <div className="space-y-6">
+        <div className="glass-panel rounded-3xl p-6">
+          <h2 className="text-xl font-semibold">Редактор уроков</h2>
+          <input
+            value={newLesson.title}
+            onChange={(event) => setNewLesson((prev) => ({ ...prev, title: event.target.value }))}
+            placeholder="Название урока"
+            className="mt-3 w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm shadow-inner transition focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20 dark:border-slate-700 dark:bg-slate-900"
+          />
+          <input
+            value={newLesson.video_url}
+            onChange={(event) => setNewLesson((prev) => ({ ...prev, video_url: event.target.value }))}
+            placeholder="Ссылка на видео (YouTube)"
+            className="mt-3 w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm shadow-inner transition focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20 dark:border-slate-700 dark:bg-slate-900"
+          />
+          <CKEditor editor={ClassicEditor} data={content} onChange={(_, editor) => setContent(editor.getData())} />
+          <div className="mt-4 flex flex-wrap gap-3">
+            <button
+              onClick={handlePreview}
+              className="rounded-full border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-primary hover:text-primary dark:border-slate-600 dark:text-slate-200"
+            >
+              Предпросмотр
+            </button>
+            <button
+              onClick={handleCreateLesson}
+              className="rounded-full bg-primary px-4 py-2 text-sm font-semibold text-white shadow-lg transition hover:bg-primary/80"
+            >
+              Сохранить урок
+            </button>
+          </div>
+        </div>
+        {preview && (
+          <div className="glass-panel rounded-3xl p-6">
+            <h2 className="text-xl font-semibold">Предпросмотр</h2>
+            <article className="prose prose-slate mt-4 max-w-none dark:prose-invert" dangerouslySetInnerHTML={{ __html: preview }}></article>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default CourseManagement;

--- a/frontend/src/pages/Admin/UserManagement.jsx
+++ b/frontend/src/pages/Admin/UserManagement.jsx
@@ -1,0 +1,150 @@
+import { useEffect, useState } from 'react';
+import {
+  deleteUser,
+  fetchUsers,
+  notifyUser,
+  updateUser
+} from '../../services/adminService';
+import LoadingOverlay from '../../components/LoadingOverlay';
+
+function UserManagement() {
+  const [users, setUsers] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [editingId, setEditingId] = useState(null);
+  const [notification, setNotification] = useState('');
+  const [toast, setToast] = useState('');
+
+  const loadUsers = () => {
+    setLoading(true);
+    fetchUsers()
+      .then(({ data }) => setUsers(data.users))
+      .finally(() => setLoading(false));
+  };
+
+  useEffect(() => {
+    loadUsers();
+  }, []);
+
+  const handleUpdate = async (userId, payload) => {
+    await updateUser(userId, payload);
+    loadUsers();
+    setToast('Данные пользователя обновлены.');
+  };
+
+  const handleBlockToggle = (user) => {
+    const nextStatus = user.status === 'active' ? 'blocked' : 'active';
+    handleUpdate(user.id, { status: nextStatus });
+  };
+
+  const handleDelete = async (userId) => {
+    await deleteUser(userId);
+    loadUsers();
+    setToast('Пользователь удален.');
+  };
+
+  const handleNotify = async (userId) => {
+    if (!notification) return;
+    await notifyUser(userId, { title: 'Сообщение от администратора', message: notification });
+    setNotification('');
+    setToast('Уведомление отправлено.');
+  };
+
+  if (loading) {
+    return <LoadingOverlay message="Загружаем пользователей..." />;
+  }
+
+  return (
+    <div className="space-y-6">
+      {toast && <p className="rounded-2xl bg-emerald-500/10 px-4 py-3 text-sm text-emerald-600 dark:text-emerald-400">{toast}</p>}
+      <div className="overflow-x-auto">
+        <table className="min-w-full divide-y divide-slate-200 text-sm dark:divide-slate-700">
+          <thead className="bg-slate-100 dark:bg-slate-800">
+            <tr className="text-left">
+              <th className="px-4 py-3 font-semibold">Email</th>
+              <th className="px-4 py-3 font-semibold">Имя</th>
+              <th className="px-4 py-3 font-semibold">Статус</th>
+              <th className="px-4 py-3 font-semibold">Роль</th>
+              <th className="px-4 py-3 font-semibold">Дата</th>
+              <th className="px-4 py-3 font-semibold">Действия</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-200 dark:divide-slate-700">
+            {users.map((user) => (
+              <tr key={user.id} className="hover:bg-slate-50/70 dark:hover:bg-slate-800/40">
+                <td className="px-4 py-3">{user.email}</td>
+                <td className="px-4 py-3">
+                  {editingId === user.id ? (
+                    <input
+                      defaultValue={user.full_name || ''}
+                      onBlur={(event) => {
+                        setEditingId(null);
+                        handleUpdate(user.id, { full_name: event.target.value });
+                      }}
+                      className="w-full rounded-xl border border-slate-200 px-2 py-1 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary/40 dark:border-slate-600 dark:bg-slate-900"
+                    />
+                  ) : (
+                    <button
+                      onClick={() => setEditingId(user.id)}
+                      className="text-left text-slate-700 transition hover:text-primary dark:text-slate-200"
+                    >
+                      {user.full_name || '—'}
+                    </button>
+                  )}
+                </td>
+                <td className="px-4 py-3">
+                  <span
+                    className={`rounded-full px-3 py-1 text-xs font-semibold ${
+                      user.status === 'active' ? 'bg-emerald-500/10 text-emerald-600' : 'bg-red-500/10 text-red-600'
+                    }`}
+                  >
+                    {user.status}
+                  </span>
+                </td>
+                <td className="px-4 py-3">{user.is_admin ? 'Админ' : 'Студент'}</td>
+                <td className="px-4 py-3 text-xs text-slate-500">
+                  {new Date(user.created_at).toLocaleDateString()}
+                </td>
+                <td className="px-4 py-3">
+                  <div className="flex flex-wrap gap-2">
+                    <button
+                      onClick={() => handleBlockToggle(user)}
+                      className="rounded-full border border-slate-200 px-3 py-1 text-xs font-semibold text-slate-700 transition hover:border-primary hover:text-primary dark:border-slate-600 dark:text-slate-200"
+                    >
+                      {user.status === 'active' ? 'Блокировать' : 'Разблокировать'}
+                    </button>
+                    <button
+                      onClick={() => handleDelete(user.id)}
+                      className="rounded-full border border-red-200 px-3 py-1 text-xs font-semibold text-red-600 transition hover:bg-red-500/10"
+                    >
+                      Удалить
+                    </button>
+                    <button
+                      onClick={() => handleNotify(user.id)}
+                      className="rounded-full border border-primary px-3 py-1 text-xs font-semibold text-primary transition hover:bg-primary/10"
+                    >
+                      Уведомить
+                    </button>
+                  </div>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <div className="rounded-3xl bg-slate-100/80 p-6 dark:bg-slate-800/60">
+        <h2 className="text-lg font-semibold">Отправить уведомление</h2>
+        <textarea
+          value={notification}
+          onChange={(event) => setNotification(event.target.value)}
+          placeholder="Введите сообщение для пользователя"
+          className="mt-3 w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm shadow-inner transition focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20 dark:border-slate-700 dark:bg-slate-900"
+        ></textarea>
+        <p className="mt-2 text-xs text-slate-500 dark:text-slate-400">
+          Выберите кнопку «Уведомить» в таблице, чтобы отправить сообщение выбранному пользователю.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export default UserManagement;

--- a/frontend/src/pages/Auth/ForgotPassword.jsx
+++ b/frontend/src/pages/Auth/ForgotPassword.jsx
@@ -1,0 +1,56 @@
+import { useState } from 'react';
+import api from '../../services/api';
+
+function ForgotPassword() {
+  const [email, setEmail] = useState('');
+  const [submitted, setSubmitted] = useState(false);
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    setError('');
+    try {
+      await api.post('/auth/forgot-password', { email });
+      setSubmitted(true);
+    } catch (err) {
+      setError(err.response?.data?.error || 'Не удалось отправить письмо.');
+    }
+  };
+
+  return (
+    <div className="flex min-h-[calc(100vh-120px)] items-center justify-center bg-gradient-to-br from-slate-100 via-white to-slate-100 px-4 py-16 dark:from-slate-900 dark:via-slate-900 dark:to-slate-900">
+      <div className="glass-panel w-full max-w-md p-8">
+        <h1 className="text-2xl font-bold">Восстановление пароля</h1>
+        <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">
+          Введите email, и мы отправим инструкции по восстановлению доступа.
+        </p>
+        <form className="mt-8 space-y-5" onSubmit={handleSubmit}>
+          <div>
+            <label className="text-sm font-semibold">Email</label>
+            <input
+              type="email"
+              required
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+              className="mt-2 w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm shadow-inner transition focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20 dark:border-slate-700 dark:bg-slate-800"
+            />
+          </div>
+          {error && <p className="text-sm text-red-500">{error}</p>}
+          <button
+            type="submit"
+            className="w-full rounded-full bg-primary px-5 py-3 text-sm font-semibold text-white shadow-lg transition hover:bg-primary/80"
+          >
+            Отправить письмо
+          </button>
+        </form>
+        {submitted && (
+          <p className="mt-6 rounded-2xl bg-green-500/10 p-4 text-sm text-green-600 dark:text-green-400">
+            Если такой аккаунт существует, мы отправили письмо с инструкциями.
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default ForgotPassword;

--- a/frontend/src/pages/Auth/Login.jsx
+++ b/frontend/src/pages/Auth/Login.jsx
@@ -1,0 +1,83 @@
+import { useState } from 'react';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
+import { useAuth } from '../../context/AuthContext';
+import LoadingOverlay from '../../components/LoadingOverlay';
+
+function Login() {
+  const { login, isLoading } = useAuth();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [form, setForm] = useState({ email: '', password: '' });
+  const [error, setError] = useState('');
+
+  const handleChange = (event) => {
+    const { name, value } = event.target;
+    setForm((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    setError('');
+    try {
+      await login(form);
+      const redirect = location.state?.from?.pathname || '/dashboard';
+      navigate(redirect);
+    } catch (err) {
+      setError(err.response?.data?.error || 'Ошибка авторизации. Проверьте данные.');
+    }
+  };
+
+  return (
+    <div className="flex min-h-[calc(100vh-120px)] items-center justify-center bg-gradient-to-br from-slate-100 via-white to-slate-100 px-4 py-16 dark:from-slate-900 dark:via-slate-900 dark:to-slate-900">
+      <div className="glass-panel w-full max-w-md p-8">
+        <h1 className="text-2xl font-bold">Добро пожаловать!</h1>
+        <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">
+          Войдите в аккаунт, чтобы продолжить обучение и отслеживать прогресс.
+        </p>
+        <form className="mt-8 space-y-5" onSubmit={handleSubmit}>
+          <div>
+            <label className="text-sm font-semibold">Email</label>
+            <input
+              type="email"
+              name="email"
+              required
+              value={form.email}
+              onChange={handleChange}
+              className="mt-2 w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm shadow-inner transition focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20 dark:border-slate-700 dark:bg-slate-800"
+            />
+          </div>
+          <div>
+            <label className="text-sm font-semibold">Пароль</label>
+            <input
+              type="password"
+              name="password"
+              required
+              value={form.password}
+              onChange={handleChange}
+              className="mt-2 w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm shadow-inner transition focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20 dark:border-slate-700 dark:bg-slate-800"
+            />
+          </div>
+          {error && <p className="text-sm text-red-500">{error}</p>}
+          <button
+            type="submit"
+            disabled={isLoading}
+            className="w-full rounded-full bg-primary px-5 py-3 text-sm font-semibold text-white shadow-lg transition hover:bg-primary/80 disabled:opacity-60"
+          >
+            Войти
+          </button>
+        </form>
+        <div className="mt-6 flex items-center justify-between text-sm text-slate-600 dark:text-slate-300">
+          <Link to="/forgot-password" className="text-primary hover:underline">
+            Забыли пароль?
+          </Link>
+          <Link to="/register" className="text-primary hover:underline">
+            Нет аккаунта?
+          </Link>
+        </div>
+        {isLoading && <LoadingOverlay message="Проверяем учетные данные..." />}
+      </div>
+    </div>
+  );
+}
+
+export default Login;

--- a/frontend/src/pages/Auth/Register.jsx
+++ b/frontend/src/pages/Auth/Register.jsx
@@ -1,0 +1,110 @@
+import { useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { useAuth } from '../../context/AuthContext';
+import LoadingOverlay from '../../components/LoadingOverlay';
+
+function Register() {
+  const { register, isLoading } = useAuth();
+  const navigate = useNavigate();
+  const [form, setForm] = useState({ email: '', password: '', confirmPassword: '', full_name: '' });
+  const [error, setError] = useState('');
+
+  const handleChange = (event) => {
+    const { name, value } = event.target;
+    setForm((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    setError('');
+    if (form.password !== form.confirmPassword) {
+      setError('Пароли должны совпадать.');
+      return;
+    }
+    if (!/(?=.*\d)(?=.*[A-Za-z]).{8,}/.test(form.password)) {
+      setError('Пароль должен содержать буквы и цифры и быть не короче 8 символов.');
+      return;
+    }
+    try {
+      await register({ email: form.email, password: form.password, full_name: form.full_name });
+      navigate('/dashboard');
+    } catch (err) {
+      setError(err.response?.data?.message || err.response?.data?.error || 'Не удалось зарегистрироваться.');
+    }
+  };
+
+  return (
+    <div className="flex min-h-[calc(100vh-120px)] items-center justify-center bg-gradient-to-br from-slate-100 via-white to-slate-100 px-4 py-16 dark:from-slate-900 dark:via-slate-900 dark:to-slate-900">
+      <div className="glass-panel w-full max-w-xl p-10">
+        <h1 className="text-2xl font-bold">Создайте аккаунт</h1>
+        <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">
+          Получите моментальный доступ к урокам, проектам и комьюнити разработчиков.
+        </p>
+        <form className="mt-8 grid gap-6" onSubmit={handleSubmit}>
+          <div>
+            <label className="text-sm font-semibold">Имя и фамилия</label>
+            <input
+              type="text"
+              name="full_name"
+              value={form.full_name}
+              onChange={handleChange}
+              className="mt-2 w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm shadow-inner transition focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20 dark:border-slate-700 dark:bg-slate-800"
+            />
+          </div>
+          <div className="grid gap-6 md:grid-cols-2">
+            <div>
+              <label className="text-sm font-semibold">Email</label>
+              <input
+                type="email"
+                name="email"
+                required
+                value={form.email}
+                onChange={handleChange}
+                className="mt-2 w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm shadow-inner transition focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20 dark:border-slate-700 dark:bg-slate-800"
+              />
+            </div>
+            <div>
+              <label className="text-sm font-semibold">Пароль</label>
+              <input
+                type="password"
+                name="password"
+                required
+                value={form.password}
+                onChange={handleChange}
+                className="mt-2 w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm shadow-inner transition focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20 dark:border-slate-700 dark:bg-slate-800"
+              />
+            </div>
+            <div>
+              <label className="text-sm font-semibold">Подтверждение пароля</label>
+              <input
+                type="password"
+                name="confirmPassword"
+                required
+                value={form.confirmPassword}
+                onChange={handleChange}
+                className="mt-2 w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm shadow-inner transition focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20 dark:border-slate-700 dark:bg-slate-800"
+              />
+            </div>
+          </div>
+          {error && <p className="text-sm text-red-500">{error}</p>}
+          <button
+            type="submit"
+            disabled={isLoading}
+            className="rounded-full bg-primary px-6 py-3 text-sm font-semibold text-white shadow-lg transition hover:bg-primary/80 disabled:opacity-60"
+          >
+            Создать аккаунт
+          </button>
+        </form>
+        <p className="mt-6 text-sm text-slate-600 dark:text-slate-300">
+          Уже обучаетесь?{' '}
+          <Link to="/login" className="text-primary hover:underline">
+            Войдите
+          </Link>
+        </p>
+        {isLoading && <LoadingOverlay message="Создаем профиль..." />}
+      </div>
+    </div>
+  );
+}
+
+export default Register;

--- a/frontend/src/pages/Course/CourseOverview.jsx
+++ b/frontend/src/pages/Course/CourseOverview.jsx
@@ -1,0 +1,110 @@
+import { useEffect, useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import { fetchCourse, fetchProgress, purchaseCourse } from '../../services/courseService';
+import { useAuth } from '../../context/AuthContext';
+import LoadingOverlay from '../../components/LoadingOverlay';
+
+function CourseOverview() {
+  const { slug } = useParams();
+  const { user } = useAuth();
+  const navigate = useNavigate();
+  const [course, setCourse] = useState(null);
+  const [progress, setProgress] = useState(0);
+  const [isPurchasing, setIsPurchasing] = useState(false);
+
+  useEffect(() => {
+    fetchCourse(slug).then(({ data }) => setCourse(data.course));
+    if (user) {
+      fetchProgress(slug).then(({ data }) => setProgress(data.progress));
+    }
+  }, [slug, user]);
+
+  const handlePurchase = async () => {
+    if (!user) {
+      navigate('/login');
+      return;
+    }
+    setIsPurchasing(true);
+    try {
+      await purchaseCourse(slug, { tier: 'premium' });
+      await fetchProgress(slug).then(({ data }) => setProgress(data.progress));
+    } finally {
+      setIsPurchasing(false);
+    }
+  };
+
+  if (!course) {
+    return <LoadingOverlay message="Загружаем курс..." />;
+  }
+
+  return (
+    <div className="bg-gradient-to-b from-slate-50 to-white py-16 dark:from-slate-950 dark:to-slate-900">
+      <div className="mx-auto max-w-6xl px-4 lg:px-8">
+        <div className="glass-panel rounded-3xl p-10">
+          <h1 className="text-3xl font-bold">{course.title}</h1>
+          <p className="mt-3 text-slate-600 dark:text-slate-300">{course.description}</p>
+          <div className="mt-6 flex flex-wrap items-center gap-4 text-sm text-slate-500 dark:text-slate-300">
+            <span>Уровень: {course.level}</span>
+            <span>Стоимость: {course.price}₽</span>
+            <span>Прогресс: {progress}%</span>
+          </div>
+          <div className="mt-6 h-3 w-full overflow-hidden rounded-full bg-slate-200 dark:bg-slate-700">
+            <div className="h-full rounded-full bg-primary" style={{ width: `${progress}%` }}></div>
+          </div>
+          <div className="mt-8 flex flex-wrap gap-3">
+            <button
+              onClick={handlePurchase}
+              disabled={isPurchasing}
+              className="rounded-full bg-primary px-6 py-3 text-sm font-semibold text-white shadow-lg transition hover:bg-primary/80 disabled:opacity-60"
+            >
+              {isPurchasing ? 'Оформляем доступ...' : 'Получить полный доступ'}
+            </button>
+            {course.hero_video_url && (
+              <a
+                href={course.hero_video_url}
+                target="_blank"
+                rel="noreferrer"
+                className="rounded-full border border-slate-200 px-6 py-3 text-sm font-semibold text-slate-700 transition hover:border-primary hover:text-primary dark:border-slate-600 dark:text-slate-200"
+              >
+                Смотреть превью
+              </a>
+            )}
+          </div>
+        </div>
+
+        <div className="mt-10 space-y-6">
+          {course.chapters.map((chapter) => (
+            <div key={chapter.id} className="glass-panel rounded-3xl p-6">
+              <h2 className="text-2xl font-semibold">{chapter.title}</h2>
+              <div className="mt-4 grid gap-4 md:grid-cols-2">
+                {chapter.sections.map((section) => (
+                  <div key={section.id} className="rounded-3xl bg-white/80 p-5 dark:bg-slate-800/60">
+                    <div className="flex items-center justify-between">
+                      <h3 className="text-base font-semibold">{section.title}</h3>
+                      <span className="text-xs uppercase tracking-widest text-primary">{section.lessons.length} уроков</span>
+                    </div>
+                    <ul className="mt-3 space-y-3 text-sm text-slate-600 dark:text-slate-300">
+                      {section.lessons.map((lesson) => (
+                        <li key={lesson.id} className="flex items-center justify-between gap-3 rounded-2xl bg-slate-100/80 px-3 py-2 dark:bg-slate-900/40">
+                          <span>{lesson.title}</span>
+                          <Link
+                            to={`/course/${course.slug}/lesson/${lesson.id}`}
+                            className="text-xs font-semibold text-primary hover:underline"
+                          >
+                            Открыть
+                          </Link>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default CourseOverview;

--- a/frontend/src/pages/Course/LessonView.jsx
+++ b/frontend/src/pages/Course/LessonView.jsx
@@ -1,0 +1,146 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import { fetchCourse, fetchLesson } from '../../services/courseService';
+import { updateProgress } from '../../services/userService';
+import LoadingOverlay from '../../components/LoadingOverlay';
+
+function LessonView() {
+  const { slug, lessonId } = useParams();
+  const navigate = useNavigate();
+  const [course, setCourse] = useState(null);
+  const [lesson, setLesson] = useState(null);
+  const [isCompleted, setIsCompleted] = useState(false);
+  const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    fetchCourse(slug).then(({ data }) => setCourse(data.course));
+  }, [slug]);
+
+  useEffect(() => {
+    fetchLesson(slug, lessonId)
+      .then(({ data }) => {
+        setLesson(data.lesson);
+        setIsCompleted(Boolean(data.lesson.completed));
+      })
+      .catch(() => navigate(`/course/${slug}`));
+  }, [slug, lessonId, navigate]);
+
+  const lessonOrder = useMemo(() => {
+    if (!course) return [];
+    const order = [];
+    course.chapters.forEach((chapter) => {
+      chapter.sections.forEach((section) => {
+        section.lessons.forEach((l) => {
+          order.push({
+            chapter: chapter.title,
+            section: section.title,
+            ...l
+          });
+        });
+      });
+    });
+    return order;
+  }, [course]);
+
+  const currentIndex = lessonOrder.findIndex((item) => String(item.id) === String(lessonId));
+  const previousLesson = currentIndex > 0 ? lessonOrder[currentIndex - 1] : null;
+  const nextLesson = currentIndex >= 0 && currentIndex < lessonOrder.length - 1 ? lessonOrder[currentIndex + 1] : null;
+
+  const handleComplete = async () => {
+    try {
+      await updateProgress({ lesson_id: Number(lessonId), completed: !isCompleted });
+      setIsCompleted((prev) => !prev);
+      setMessage(!isCompleted ? 'Урок отмечен как пройденный!' : 'Прогресс обновлен.');
+    } catch (error) {
+      setMessage(error.response?.data?.error || 'Не удалось обновить прогресс.');
+    }
+  };
+
+  if (!lesson) {
+    return <LoadingOverlay message="Открываем урок..." />;
+  }
+
+  const attachments = (() => {
+    try {
+      return lesson.attachments ? JSON.parse(lesson.attachments) : [];
+    } catch (error) {
+      return [];
+    }
+  })();
+
+  return (
+    <div className="bg-white py-16 dark:bg-slate-900">
+      <div className="mx-auto max-w-5xl px-4 lg:px-0">
+        <div className="glass-panel rounded-3xl p-8">
+          <div className="flex flex-col gap-2">
+            <Link to={`/course/${slug}`} className="text-xs font-semibold uppercase tracking-widest text-primary">
+              ← Назад к курсу
+            </Link>
+            <h1 className="text-3xl font-bold">{lesson.title}</h1>
+            {lessonOrder[currentIndex] && (
+              <p className="text-sm text-slate-500 dark:text-slate-300">
+                {lessonOrder[currentIndex].chapter} • {lessonOrder[currentIndex].section}
+              </p>
+            )}
+          </div>
+          {lesson.video_url && (
+            <iframe
+              className="mt-6 aspect-video w-full rounded-3xl"
+              src={lesson.video_url}
+              title={lesson.title}
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+              allowFullScreen
+            ></iframe>
+          )}
+          <article
+            className="prose prose-slate mt-8 max-w-none dark:prose-invert"
+            dangerouslySetInnerHTML={{ __html: lesson.content }}
+          ></article>
+          {attachments.length > 0 && (
+            <div className="mt-8 rounded-3xl bg-slate-100/80 p-6 dark:bg-slate-800/60">
+              <h2 className="text-lg font-semibold">Материалы для скачивания</h2>
+              <ul className="mt-3 space-y-2 text-sm text-primary">
+                {attachments.map((file) => (
+                  <li key={file}>
+                    <a href={`/${file}`} download className="hover:underline">
+                      {file}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+          <div className="mt-10 flex flex-wrap items-center gap-3">
+            <button
+              onClick={handleComplete}
+              className={`rounded-full px-6 py-3 text-sm font-semibold text-white shadow-lg transition ${
+                isCompleted ? 'bg-emerald-500 hover:bg-emerald-600' : 'bg-primary hover:bg-primary/80'
+              }`}
+            >
+              {isCompleted ? 'Отметить как непройденный' : 'Отметить как пройденный'}
+            </button>
+            {previousLesson && (
+              <Link
+                to={`/course/${slug}/lesson/${previousLesson.id}`}
+                className="rounded-full border border-slate-200 px-6 py-3 text-sm font-semibold text-slate-700 transition hover:border-primary hover:text-primary dark:border-slate-600 dark:text-slate-200"
+              >
+                ← Предыдущий урок
+              </Link>
+            )}
+            {nextLesson && (
+              <Link
+                to={`/course/${slug}/lesson/${nextLesson.id}`}
+                className="rounded-full border border-primary bg-primary/10 px-6 py-3 text-sm font-semibold text-primary transition hover:bg-primary/20"
+              >
+                Следующий урок →
+              </Link>
+            )}
+          </div>
+          {message && <p className="mt-4 text-sm text-slate-600 dark:text-slate-300">{message}</p>}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default LessonView;

--- a/frontend/src/pages/Dashboard/UserDashboard.jsx
+++ b/frontend/src/pages/Dashboard/UserDashboard.jsx
@@ -1,0 +1,112 @@
+import { useEffect, useState } from 'react';
+import { useAuth } from '../../context/AuthContext';
+import { fetchNotifications, fetchPurchases, updateProfile } from '../../services/userService';
+import { fetchCourses } from '../../services/courseService';
+
+function UserDashboard() {
+  const { user, refreshProfile } = useAuth();
+  const [purchases, setPurchases] = useState([]);
+  const [courses, setCourses] = useState([]);
+  const [notifications, setNotifications] = useState([]);
+  const [fullName, setFullName] = useState(user?.full_name || '');
+  const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    fetchPurchases().then(({ data }) => setPurchases(data.purchases));
+    fetchNotifications().then(({ data }) => setNotifications(data.notifications));
+    fetchCourses().then(({ data }) => setCourses(data.courses));
+  }, []);
+
+  const handleSaveProfile = async () => {
+    await updateProfile({ full_name: fullName });
+    await refreshProfile();
+    setMessage('Профиль обновлен!');
+  };
+
+  return (
+    <div className="bg-slate-50 py-16 dark:bg-slate-950">
+      <div className="mx-auto max-w-6xl px-4 lg:px-8">
+        <div className="grid gap-8 lg:grid-cols-[2fr,1fr]">
+          <div className="space-y-8">
+            <div className="glass-panel rounded-3xl p-8">
+              <h1 className="text-3xl font-bold">Привет, {user?.full_name || 'студент'} 👋</h1>
+              <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">
+                Отслеживайте прогресс, скачивайте материалы и продолжайте обучение.
+              </p>
+              <div className="mt-6 grid gap-6 md:grid-cols-2">
+                <div className="rounded-3xl bg-white/80 p-6 dark:bg-slate-800/60">
+                  <h2 className="text-lg font-semibold">Профиль</h2>
+                  <label className="mt-4 block text-xs font-semibold uppercase tracking-widest text-slate-500">
+                    Имя и фамилия
+                  </label>
+                  <input
+                    value={fullName}
+                    onChange={(event) => setFullName(event.target.value)}
+                    className="mt-2 w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm shadow-inner transition focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20 dark:border-slate-700 dark:bg-slate-900"
+                  />
+                  <button
+                    onClick={handleSaveProfile}
+                    className="mt-4 rounded-full bg-primary px-4 py-2 text-sm font-semibold text-white shadow-lg transition hover:bg-primary/80"
+                  >
+                    Сохранить
+                  </button>
+                  {message && <p className="mt-2 text-xs text-emerald-500">{message}</p>}
+                </div>
+                <div className="rounded-3xl bg-gradient-to-br from-primary/10 via-accent/10 to-primary/5 p-6">
+                  <h2 className="text-lg font-semibold">Сертификат</h2>
+                  <p className="mt-2 text-sm text-slate-600 dark:text-slate-200">
+                    Завершите все уроки и получите именной сертификат с уникальным номером.
+                  </p>
+                  <button className="mt-4 rounded-full border border-primary px-4 py-2 text-sm font-semibold text-primary transition hover:bg-primary/10">
+                    Скачать сертификат
+                  </button>
+                </div>
+              </div>
+            </div>
+
+            <div className="glass-panel rounded-3xl p-8">
+              <h2 className="text-2xl font-semibold">Мои покупки</h2>
+              <div className="mt-6 grid gap-6 md:grid-cols-2">
+                {purchases.map((purchase) => (
+                  <div key={purchase.id} className="rounded-3xl bg-white/80 p-5 dark:bg-slate-800/60">
+                    <p className="text-sm font-semibold text-slate-700 dark:text-slate-200">
+                      Курс ID: {purchase.course_id}
+                    </p>
+                    <p className="mt-2 text-sm text-slate-500 dark:text-slate-300">Статус: {purchase.status}</p>
+                    <p className="text-sm text-slate-500 dark:text-slate-300">Тариф: {purchase.tier}</p>
+                    <p className="text-xs text-slate-400">Дата: {new Date(purchase.created_at).toLocaleDateString()}</p>
+                  </div>
+                ))}
+                {purchases.length === 0 && <p className="text-sm text-slate-600 dark:text-slate-300">Покупок пока нет.</p>}
+              </div>
+            </div>
+          </div>
+          <aside className="space-y-8">
+            <div className="glass-panel rounded-3xl p-6">
+              <h2 className="text-lg font-semibold">Уведомления</h2>
+              <ul className="mt-4 space-y-4 text-sm text-slate-600 dark:text-slate-300">
+                {notifications.map((notification) => (
+                  <li key={notification.id} className="rounded-2xl bg-white/80 p-4 dark:bg-slate-800/60">
+                    <p className="font-semibold">{notification.title}</p>
+                    <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">{notification.message}</p>
+                  </li>
+                ))}
+                {notifications.length === 0 && <p className="text-sm text-slate-600 dark:text-slate-300">Новых уведомлений нет.</p>}
+              </ul>
+            </div>
+            <div className="glass-panel rounded-3xl p-6">
+              <h2 className="text-lg font-semibold">Рекомендованные курсы</h2>
+              <ul className="mt-4 space-y-3 text-sm text-primary">
+                {courses.slice(0, 3).map((course) => (
+                  <li key={course.id}>{course.title}</li>
+                ))}
+              </ul>
+            </div>
+          </aside>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default UserDashboard;

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -1,0 +1,149 @@
+import { useEffect, useMemo, useState } from 'react';
+import Hero from '../components/Hero';
+import FeatureHighlights from '../components/FeatureHighlights';
+import CurriculumOverview from '../components/CurriculumOverview';
+import SubscriptionPlans from '../components/SubscriptionPlans';
+import TestimonialCarousel from '../components/TestimonialCarousel';
+import FAQAccordion from '../components/FAQAccordion';
+import { fetchCourse, fetchCourses, purchaseCourse } from '../services/courseService';
+import { useAuth } from '../context/AuthContext';
+import LoadingOverlay from '../components/LoadingOverlay';
+import { Link, useNavigate } from 'react-router-dom';
+
+function Home() {
+  const [featuredCourse, setFeaturedCourse] = useState(null);
+  const [courses, setCourses] = useState([]);
+  const [search, setSearch] = useState('');
+  const [isPurchasing, setIsPurchasing] = useState(false);
+  const { user } = useAuth();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    fetchCourse('python-mastery').then(({ data }) => setFeaturedCourse(data.course));
+    fetchCourses().then(({ data }) => setCourses(data.courses));
+  }, []);
+
+  const filteredCourses = useMemo(() => {
+    if (!search) return courses;
+    return courses.filter((course) => course.title.toLowerCase().includes(search.toLowerCase()));
+  }, [courses, search]);
+
+  const handlePurchase = async (plan) => {
+    if (!user) {
+      navigate('/login');
+      return;
+    }
+    if (!featuredCourse) return;
+    setIsPurchasing(true);
+    try {
+      await purchaseCourse(featuredCourse.slug, { tier: plan.tier });
+      navigate(`/course/${featuredCourse.slug}`);
+    } finally {
+      setIsPurchasing(false);
+    }
+  };
+
+  return (
+    <>
+      <Hero />
+      <FeatureHighlights />
+      <section className="bg-white py-20 dark:bg-slate-900">
+        <div className="mx-auto max-w-6xl px-4 lg:px-8">
+          <div className="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
+            <div>
+              <h2 className="text-3xl font-bold">Каталог курсов</h2>
+              <p className="mt-2 text-slate-600 dark:text-slate-300">
+                Актуальные направления Python: от автоматизации до backend и data.
+              </p>
+            </div>
+            <input
+              type="search"
+              value={search}
+              onChange={(event) => setSearch(event.target.value)}
+              placeholder="Найти курс..."
+              className="w-full rounded-full border border-slate-200 bg-slate-50 px-5 py-3 text-sm shadow-inner transition focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/30 dark:border-slate-700 dark:bg-slate-800 md:w-80"
+            />
+          </div>
+          <div className="mt-10 grid gap-8 md:grid-cols-2">
+            {filteredCourses.map((course) => (
+              <div key={course.id} className="glass-panel card-hover flex flex-col rounded-3xl p-6">
+                <h3 className="text-xl font-semibold">{course.title}</h3>
+                <p className="mt-3 text-sm text-slate-600 dark:text-slate-300">{course.description}</p>
+                <div className="mt-4 flex items-center gap-4 text-sm text-slate-500 dark:text-slate-400">
+                  <span>Уровень: {course.level}</span>
+                  <span>Стоимость: {course.price}₽</span>
+                </div>
+                <div className="mt-6 flex flex-wrap gap-3">
+                  <Link
+                    to={`/course/${course.slug}`}
+                    className="rounded-full border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-primary hover:text-primary dark:border-slate-600 dark:text-slate-200"
+                  >
+                    Смотреть программу
+                  </Link>
+                  <button
+                    onClick={() => handlePurchase({ tier: 'premium' })}
+                    className="rounded-full bg-primary px-4 py-2 text-sm font-semibold text-white shadow-lg transition hover:bg-primary/80"
+                  >
+                    Купить курс
+                  </button>
+                </div>
+              </div>
+            ))}
+            {filteredCourses.length === 0 && (
+              <p className="text-sm text-slate-600 dark:text-slate-300">Курсы не найдены.</p>
+            )}
+          </div>
+        </div>
+      </section>
+      <CurriculumOverview />
+      <section className="bg-slate-50 py-20 dark:bg-slate-950">
+        <div className="mx-auto max-w-5xl px-4 lg:px-0">
+          <div className="glass-panel rounded-3xl p-8">
+            <h2 className="text-3xl font-bold">Превью курса</h2>
+            {!featuredCourse && <LoadingOverlay message="Загружаем программу курса..." />}
+            {featuredCourse && (
+              <div className="mt-6 grid gap-6 md:grid-cols-2">
+                <div>
+                  <p className="text-sm text-slate-600 dark:text-slate-300">{featuredCourse.description}</p>
+                  <ul className="mt-4 space-y-3 text-sm text-slate-600 dark:text-slate-300">
+                    {featuredCourse.chapters.map((chapter) => (
+                      <li key={chapter.id} className="rounded-2xl bg-white/80 p-4 dark:bg-slate-800/60">
+                        <h3 className="text-base font-semibold">{chapter.title}</h3>
+                        <ul className="mt-2 list-disc space-y-1 pl-5">
+                          {chapter.sections.map((section) => (
+                            <li key={section.id}>{section.title}</li>
+                          ))}
+                        </ul>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+                <div className="rounded-3xl bg-gradient-to-br from-primary/10 via-accent/10 to-primary/5 p-6">
+                  <h3 className="text-lg font-semibold">Что вы получите</h3>
+                  <ul className="mt-4 space-y-3 text-sm text-slate-700 dark:text-slate-200">
+                    <li>✔ Полный доступ к главам и проектам</li>
+                    <li>✔ Практику по встроенным библиотекам</li>
+                    <li>✔ Скачиваемые материалы и код</li>
+                    <li>✔ Сертификат и карьерное сопровождение</li>
+                  </ul>
+                  <button
+                    onClick={() => handlePurchase({ tier: 'premium' })}
+                    disabled={isPurchasing}
+                    className="mt-6 inline-flex items-center justify-center rounded-full bg-primary px-6 py-3 text-sm font-semibold text-white shadow-lg transition hover:bg-primary/80 disabled:opacity-60"
+                  >
+                    {isPurchasing ? 'Обработка оплаты...' : 'Получить полный доступ'}
+                  </button>
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      </section>
+      <SubscriptionPlans onSelect={handlePurchase} />
+      <TestimonialCarousel />
+      <FAQAccordion />
+    </>
+  );
+}
+
+export default Home;

--- a/frontend/src/services/adminService.js
+++ b/frontend/src/services/adminService.js
@@ -1,0 +1,50 @@
+import api from './api';
+
+export function fetchUsers() {
+  return api.get('/admin/users');
+}
+
+export function updateUser(userId, payload) {
+  return api.patch(`/admin/users/${userId}`, payload);
+}
+
+export function deleteUser(userId) {
+  return api.delete(`/admin/users/${userId}`);
+}
+
+export function notifyUser(userId, payload) {
+  return api.post(`/admin/users/${userId}/notify`, payload);
+}
+
+export function createCourse(payload) {
+  return api.post('/admin/courses', payload);
+}
+
+export function updateCourse(courseId, payload) {
+  return api.put(`/admin/courses/${courseId}`, payload);
+}
+
+export function deleteCourse(courseId) {
+  return api.delete(`/admin/courses/${courseId}`);
+}
+
+export function createChapter(courseId, payload) {
+  return api.post(`/admin/courses/${courseId}/chapters`, payload);
+}
+
+export function createSection(chapterId, payload) {
+  return api.post(`/admin/chapters/${chapterId}/sections`, payload);
+}
+
+export function createLesson(sectionId, payload) {
+  return api.post(`/admin/sections/${sectionId}/lessons`, payload);
+}
+
+export function updateLesson(lessonId, payload) {
+  return api.put(`/admin/lessons/${lessonId}`, payload);
+}
+
+export function previewContent(payload) {
+  return api.post('/admin/preview', payload);
+}
+

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,0 +1,19 @@
+import axios from 'axios';
+
+const api = axios.create({
+  baseURL: '/api'
+});
+
+api.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    if (error.response?.status === 401) {
+      localStorage.removeItem('python_mastery_access');
+      localStorage.removeItem('python_mastery_refresh');
+      localStorage.removeItem('python_mastery_user');
+    }
+    return Promise.reject(error);
+  }
+);
+
+export default api;

--- a/frontend/src/services/courseService.js
+++ b/frontend/src/services/courseService.js
@@ -1,0 +1,22 @@
+import api from './api';
+
+export function fetchCourses(params = {}) {
+  return api.get('/courses/', { params });
+}
+
+export function fetchCourse(slug) {
+  return api.get(`/courses/${slug}`);
+}
+
+export function purchaseCourse(slug, payload) {
+  return api.post(`/courses/${slug}/purchase`, payload);
+}
+
+export function fetchLesson(slug, lessonId) {
+  return api.get(`/courses/${slug}/lessons/${lessonId}`);
+}
+
+export function fetchProgress(slug) {
+  return api.get(`/courses/${slug}/progress`);
+}
+

--- a/frontend/src/services/userService.js
+++ b/frontend/src/services/userService.js
@@ -1,0 +1,22 @@
+import api from './api';
+
+export function updateProfile(payload) {
+  return api.put('/user/me', payload);
+}
+
+export function fetchPurchases() {
+  return api.get('/user/purchases');
+}
+
+export function updateProgress(payload) {
+  return api.post('/user/progress', payload);
+}
+
+export function fetchNotifications() {
+  return api.get('/user/notifications');
+}
+
+export function markNotifications(ids) {
+  return api.post('/user/notifications/read', { ids });
+}
+

--- a/frontend/tailwind.config.cjs
+++ b/frontend/tailwind.config.cjs
@@ -1,0 +1,20 @@
+module.exports = {
+  darkMode: 'class',
+  content: ['./index.html', './src/**/*.{js,jsx,ts,tsx}'],
+  theme: {
+    extend: {
+      colors: {
+        primary: '#38bdf8',
+        accent: '#f97316'
+      },
+      fontFamily: {
+        display: ['"Fira Sans"', 'ui-sans-serif', 'system-ui'],
+        body: ['"Inter"', 'ui-sans-serif', 'system-ui']
+      },
+      boxShadow: {
+        glass: '0 10px 40px rgba(15, 23, 42, 0.25)'
+      }
+    }
+  },
+  plugins: []
+};

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    proxy: {
+      '/api': 'http://localhost:5000'
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- implement Flask backend with JWT auth, purchases, admin controls, seeded Python course and email notifications
- add SQLAlchemy models for users, courses, lessons, progress, purchases and admin logging with demo data seeding
- build React/Tailwind frontend featuring hero landing page, subscription plans, dashboards, lesson player, and admin WYSIWYG tools

## Testing
- python -m compileall backend
- npm install --legacy-peer-deps *(fails: registry returned 403 for @ckeditor/ckeditor5-build-classic)*

------
https://chatgpt.com/codex/tasks/task_e_68d15504f2b88320bc9f8eeb8b699d0f